### PR TITLE
feat: add robust file logging and migrate to structured logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ OPNSENSE_VERIFY_SSL=false
 #   /sse      - Legacy SSE transport
 #   /health   - Health check
 
+# Logging Configuration (Optional)
+# LOG_LEVEL=INFO                 # ERROR, WARN, INFO, DEBUG (default: INFO)
+# LOG_FILE=/tmp/opnsense-mcp.log # Path to log file (enables file logging)
+# LOG_MAX_SIZE=10485760          # Max log file size in bytes before rotation (default: 10MB)
+# LOG_MAX_FILES=5                # Number of rotated files to keep (default: 5)
+
 # SSH Configuration (Optional - for advanced features)
 OPNSENSE_SSH_HOST=your-opnsense-host
 OPNSENSE_SSH_PORT=22

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,7 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 import https from 'https';
 import { APICall } from '../macro/types.js';
+import { logger } from '../utils/logger.js';
 
 /**
  * Custom error class for OPNsense API errors
@@ -54,7 +55,7 @@ export class OPNSenseAPIClient {
     this.axios.interceptors.request.use(
       (config) => {
         if (this.debugMode) {
-          console.log('[API Request]', {
+          logger.debug('[API Request]', {
             method: config.method?.toUpperCase(),
             url: config.url,
             headers: config.headers,
@@ -65,7 +66,7 @@ export class OPNSenseAPIClient {
       },
       (error) => {
         if (this.debugMode) {
-          console.error('[API Request Error]', error);
+          logger.error('[API Request Error]', error);
         }
         return Promise.reject(error);
       }
@@ -75,7 +76,7 @@ export class OPNSenseAPIClient {
     this.axios.interceptors.response.use(
       (response) => {
         if (this.debugMode) {
-          console.log('[API Response]', {
+          logger.debug('[API Response]', {
             status: response.status,
             statusText: response.statusText,
             data: response.data
@@ -85,7 +86,7 @@ export class OPNSenseAPIClient {
       },
       (error: AxiosError) => {
         if (this.debugMode) {
-          console.error('[API Response Error]', {
+          logger.error('[API Response Error]', {
             status: error.response?.status,
             statusText: error.response?.statusText,
             data: error.response?.data

--- a/src/cache/enhanced-manager.ts
+++ b/src/cache/enhanced-manager.ts
@@ -1,5 +1,6 @@
 // Enhanced MCP Cache Manager with Drizzle ORM
 import { OPNSenseAPIClient } from '../api/client.js';
+import { logger } from '../utils/logger.js';
 import Redis from 'ioredis';
 import * as zlib from 'zlib';
 import { promisify } from 'util';
@@ -137,7 +138,7 @@ export class EnhancedCacheManager {
       }
 
       this.redis.on('ready', () => {
-        console.log('✅ Redis connection established');
+        logger.info('Redis connection established');
       });
 
       // Load invalidation rules
@@ -149,7 +150,7 @@ export class EnhancedCacheManager {
       }
 
     } catch (error) {
-      console.error('Failed to initialize cache connections:', error);
+      logger.error('Failed to initialize cache connections:', error);
     }
   }
 
@@ -212,7 +213,7 @@ export class EnhancedCacheManager {
         }
       }
     } catch (error) {
-      console.error('Cache get error:', error);
+      logger.error('Cache get error:', error);
     }
 
     // Cache miss - fetch from API
@@ -350,7 +351,7 @@ export class EnhancedCacheManager {
       });
 
     } catch (error) {
-      console.error('Cache invalidation error:', error);
+      logger.error('Cache invalidation error:', error);
       throw error;
     }
   }
@@ -479,7 +480,7 @@ export class EnhancedCacheManager {
         }
       };
     } catch (error) {
-      console.error('Fetch and cache error:', error);
+      logger.error('Fetch and cache error:', error);
       throw error;
     }
   }
@@ -534,7 +535,7 @@ export class EnhancedCacheManager {
           }
         });
     } catch (error) {
-      console.error('Failed to update cache stats:', error);
+      logger.error('Failed to update cache stats:', error);
     }
   }
 
@@ -576,7 +577,7 @@ export class EnhancedCacheManager {
         this.patternCache.set(keyInfo.pattern, updated[0]);
       }
     } catch (error) {
-      console.error('Failed to update query pattern:', error);
+      logger.error('Failed to update query pattern:', error);
     }
   }
 
@@ -589,7 +590,7 @@ export class EnhancedCacheManager {
       
       this.invalidationRules = rules;
     } catch (error) {
-      console.error('Failed to load invalidation rules:', error);
+      logger.error('Failed to load invalidation rules:', error);
     }
   }
 
@@ -626,7 +627,7 @@ export class EnhancedCacheManager {
         timestamp: new Date()
       });
     } catch (error) {
-      console.error('Failed to log operation:', error);
+      logger.error('Failed to log operation:', error);
     }
   }
 
@@ -713,7 +714,7 @@ export class EnhancedCacheManager {
             .where(eq(queryPatterns.id, pattern.id));
         }
       } catch (error) {
-        console.error('Pattern analysis error:', error);
+        logger.error('Pattern analysis error:', error);
       }
     }, 5 * 60 * 1000);
   }

--- a/src/cache/manager.ts
+++ b/src/cache/manager.ts
@@ -1,5 +1,6 @@
 // MCP Cache Manager for Local Infrastructure Integration
 import { OPNSenseAPIClient } from '../api/client.js';
+import { logger } from '../utils/logger.js';
 import Redis from 'ioredis';
 import pkg from 'pg';
 const { Pool } = pkg;
@@ -86,11 +87,11 @@ export class MCPCacheManager {
       });
 
       this.redisClient.on('connect', () => {
-        console.log(`Connected to Redis at ${this.config.redisHost}:${this.config.redisPort} (using database ${this.config.redisDb})`);
+        logger.info(`Connected to Redis at ${this.config.redisHost}:${this.config.redisPort} (using database ${this.config.redisDb})`);
       });
 
       this.redisClient.on('error', (err) => {
-        console.error('Redis connection error:', err);
+        logger.error('Redis connection error:', err);
       });
 
       // Connect to PostgreSQL
@@ -108,9 +109,9 @@ export class MCPCacheManager {
       // Set search path to include opnsense schema
       await this.pgPool.query(`SET search_path TO ${this.config.postgresSchema}, public`);
       
-      console.log(`Connected to PostgreSQL at ${this.config.postgresHost}:${this.config.postgresPort}/${this.config.postgresDb} (schema: ${this.config.postgresSchema})`);
+      logger.info(`Connected to PostgreSQL at ${this.config.postgresHost}:${this.config.postgresPort}/${this.config.postgresDb} (schema: ${this.config.postgresSchema})`);
     } catch (error) {
-      console.error('Failed to initialize cache connections:', error);
+      logger.error('Failed to initialize cache connections:', error);
     }
   }
 
@@ -145,7 +146,7 @@ export class MCPCacheManager {
         };
       }
     } catch (error) {
-      console.error('Redis get error:', error);
+      logger.error('Redis get error:', error);
     }
 
     // Fetch from API
@@ -159,7 +160,7 @@ export class MCPCacheManager {
         JSON.stringify(data)
       );
     } catch (error) {
-      console.error('Redis set error:', error);
+      logger.error('Redis set error:', error);
     }
     
     // Log cache miss
@@ -187,10 +188,10 @@ export class MCPCacheManager {
         // Remove the key prefix before deleting
         const unprefixedKeys = keys.map(k => k.replace(this.keyPrefix, ''));
         await this.redisClient.del(...unprefixedKeys);
-        console.log(`Invalidated ${keys.length} cache entries matching: ${this.keyPrefix}${pattern}`);
+        logger.info(`Invalidated ${keys.length} cache entries matching: ${this.keyPrefix}${pattern}`);
       }
     } catch (error) {
-      console.error('Cache invalidation error:', error);
+      logger.error('Cache invalidation error:', error);
     }
   }
 
@@ -203,7 +204,7 @@ export class MCPCacheManager {
       const cached = await this.redisClient.get(key);
       return cached ? JSON.parse(cached) : null;
     } catch (error) {
-      console.error('Redis getValue error:', error);
+      logger.error('Redis getValue error:', error);
       return null;
     }
   }
@@ -221,7 +222,7 @@ export class MCPCacheManager {
         await this.redisClient.set(key, serialized);
       }
     } catch (error) {
-      console.error('Redis set error:', error);
+      logger.error('Redis set error:', error);
     }
   }
 
@@ -305,7 +306,7 @@ export class MCPCacheManager {
         await this.redisClient.expire(recentKey, 3600); // 1 hour TTL
       }
     } catch (error) {
-      console.error('Failed to log operation:', error);
+      logger.error('Failed to log operation:', error);
     }
   }
 
@@ -321,7 +322,7 @@ export class MCPCacheManager {
           return operations.map(op => JSON.parse(op));
         }
       } catch (error) {
-        console.error('Redis operations fetch error:', error);
+        logger.error('Redis operations fetch error:', error);
       }
     }
 
@@ -334,7 +335,7 @@ export class MCPCacheManager {
         );
         return result.rows;
       } catch (error) {
-        console.error('PostgreSQL operations fetch error:', error);
+        logger.error('PostgreSQL operations fetch error:', error);
       }
     }
 
@@ -359,9 +360,9 @@ export class MCPCacheManager {
         timestamp: new Date()
       }));
       
-      console.log(`Queued command ${command.id} to ${queueKey}`);
+      logger.info(`Queued command ${command.id} to ${queueKey}`);
     } catch (error) {
-      console.error('Failed to queue command:', error);
+      logger.error('Failed to queue command:', error);
     }
   }
 
@@ -393,7 +394,7 @@ export class MCPCacheManager {
           };
         }
       } catch (error) {
-        console.error('Redis health check failed:', error);
+        logger.error('Redis health check failed:', error);
       }
     }
 
@@ -407,7 +408,7 @@ export class MCPCacheManager {
           schema: result.rows[0].current_schema
         };
       } catch (error) {
-        console.error('PostgreSQL health check failed:', error);
+        logger.error('PostgreSQL health check failed:', error);
       }
     }
 
@@ -429,7 +430,7 @@ export class MCPCacheManager {
       );
     } catch (error) {
       // Don't fail operations due to logging errors
-      console.error('Cache access logging error:', error);
+      logger.error('Cache access logging error:', error);
     }
   }
 
@@ -462,7 +463,7 @@ export class MCPCacheManager {
         recentStats: result.rows
       };
     } catch (error) {
-      console.error('Failed to get cache stats:', error);
+      logger.error('Failed to get cache stats:', error);
       return { hits: 0, misses: 0, hitRate: 0, recentStats: [] };
     }
   }

--- a/src/core/event-bus/bus.ts
+++ b/src/core/event-bus/bus.ts
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from 'events';
 import { randomUUID } from 'crypto';
+import { logger } from '../../utils/logger.js';
 import {
   EventSeverity,
   type Event,
@@ -76,7 +77,7 @@ export class EventBus extends EventEmitter {
         try {
           subscription.handler(fullEvent);
         } catch (error) {
-          console.error(`Error in event handler for ${subscription.id}:`, error);
+          logger.error(`Error in event handler for ${subscription.id}:`, error);
         }
       }
     }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 // Drizzle Configuration and Database Connection
+import { logger } from '../utils/logger.js';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import pkg from 'pg';
@@ -67,11 +68,11 @@ export async function closeDb() {
 // Run migrations
 export async function runMigrations(db: ReturnType<typeof createDb>) {
   try {
-    console.log('Running database migrations...');
+    logger.info('Running database migrations...');
     await migrate(db, { migrationsFolder: './migrations' });
-    console.log('Migrations completed successfully');
+    logger.info('Migrations completed successfully');
   } catch (error) {
-    console.error('Migration failed:', error);
+    logger.error('Migration failed:', error);
     throw error;
   }
 }

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,4 +1,5 @@
 // Database Migration Runner
+import { logger } from '../utils/logger.js';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import pkg from 'pg';
@@ -8,7 +9,7 @@ import * as schema from './schema.js';
 // Environment variables are provided by Claude Desktop/Code or npm scripts
 
 async function runMigrations() {
-  console.log('🚀 Starting database migrations...');
+  logger.info('Starting database migrations...');
   
   const pool = new Pool({
     host: process.env.POSTGRES_HOST || 'localhost',
@@ -22,12 +23,12 @@ async function runMigrations() {
   try {
     const db = drizzle(pool, { schema });
     
-    console.log('📦 Running migrations...');
+    logger.info('Running migrations...');
     await migrate(db, { migrationsFolder: './migrations' });
     
-    console.log('✅ Migrations completed successfully!');
+    logger.info('Migrations completed successfully');
   } catch (error) {
-    console.error('❌ Migration failed:', error);
+    logger.error('Migration failed:', error);
     process.exit(1);
   } finally {
     await pool.end();

--- a/src/db/network-query/mcp-integration.ts
+++ b/src/db/network-query/mcp-integration.ts
@@ -1,4 +1,5 @@
 // MCP Integration for Natural Language Network Queries
+import { logger } from '../../utils/logger.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -378,12 +379,12 @@ export class NetworkQueryMCP {
     // Start periodic sync
     await this.startPeriodicSync();
     
-    console.error('Network Query MCP server started');
+    logger.info('Network Query MCP server started');
   }
 }
 
 // Start the server
 if (require.main === module) {
   const server = new NetworkQueryMCP();
-  server.start().catch(console.error);
+  server.start().catch((err) => logger.error('Failed to start server:', err));
 }

--- a/src/examples/cached-tools.ts
+++ b/src/examples/cached-tools.ts
@@ -1,4 +1,5 @@
 // Example: Using Enhanced Cache Manager in MCP Tools
+import { logger } from '../utils/logger.js';
 import { OPNSenseAPIClient } from '../api/client.js';
 import { EnhancedCacheManager } from '../cache/enhanced-manager.js';
 import { z } from 'zod';
@@ -120,7 +121,7 @@ export class CachedOPNSenseTools {
 
       return result;
     } catch (error) {
-      console.error('Failed to create firewall rule:', error);
+      logger.error('Failed to create firewall rule:', error);
       throw error;
     }
   }
@@ -173,7 +174,7 @@ export class CachedOPNSenseTools {
    * Pre-warm cache for critical data
    */
   async warmCache() {
-    console.log('🔥 Pre-warming cache...');
+    logger.info('Pre-warming cache...');
     
     // Pre-fetch critical data in parallel
     await Promise.all([
@@ -183,7 +184,7 @@ export class CachedOPNSenseTools {
       this.getSystemInfo(),
     ]);
 
-    console.log('✅ Cache warmed successfully');
+    logger.info('Cache warmed successfully');
   }
 
   // Private helper methods

--- a/src/macro/recorder.ts
+++ b/src/macro/recorder.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { logger } from '../utils/logger.js';
 import { JSONPath } from 'jsonpath-plus';
 import { 
   APICall, 
@@ -263,7 +264,7 @@ export class MacroRecorder implements IMacroRecorder {
           const results = JSONPath({ path: expression, json: context });
           value = results.length > 0 ? results[0] : match[0]; // Keep original if no match
         } catch (error) {
-          console.warn(`Invalid JSONPath expression: ${expression}`, error);
+          logger.warn(`Invalid JSONPath expression: ${expression}`, error);
           value = match[0]; // Keep original on error
         }
       } else {

--- a/src/resources/diagnostics/routing.ts
+++ b/src/resources/diagnostics/routing.ts
@@ -1,6 +1,7 @@
 // Routing Diagnostics Resource Implementation
 // Provides comprehensive diagnostics and fixes for inter-VLAN routing issues
 import { OPNSenseAPIClient } from '../../api/client.js';
+import { logger } from '../../utils/logger.js';
 import { InterfaceConfigResource } from '../network/interfaces.js';
 import { FirewallRuleResource } from '../firewall/rule.js';
 import SystemSettingsResource from '../system/settings.js';
@@ -58,38 +59,36 @@ export class RoutingDiagnosticsResource {
    * Run comprehensive routing diagnostics
    */
   async runDiagnostics(sourceNetwork?: string, destNetwork?: string): Promise<RoutingDiagnosticResult> {
-    console.log('\n========================================');
-    console.log('  OPNsense Inter-VLAN Routing Diagnostics');
-    console.log('========================================\n');
+    logger.info('OPNsense Inter-VLAN Routing Diagnostics starting');
 
     const issues: RoutingIssue[] = [];
     const recommendations: string[] = [];
     const timestamp = new Date().toISOString();
 
     // 1. Check interface blocking settings
-    console.log('1. Checking interface blocking settings...');
+    logger.info('1. Checking interface blocking settings...');
     const interfaceIssues = await this.checkInterfaceBlocking();
     issues.push(...interfaceIssues);
 
     // 2. Check system-level routing settings
-    console.log('\n2. Checking system-level routing settings...');
+    logger.info('2. Checking system-level routing settings...');
     const systemIssues = await this.checkSystemSettings();
     issues.push(...systemIssues);
 
     // 3. Check firewall rules
-    console.log('\n3. Checking firewall rules...');
+    logger.info('3. Checking firewall rules...');
     if (sourceNetwork && destNetwork) {
       const firewallIssues = await this.checkFirewallRules(sourceNetwork, destNetwork);
       issues.push(...firewallIssues);
     }
 
     // 4. Check routing table
-    console.log('\n4. Checking routing table...');
+    logger.info('4. Checking routing table...');
     const routingTableIssues = await this.checkRoutingTable();
     issues.push(...routingTableIssues);
 
     // 5. Check NAT rules that might interfere
-    console.log('\n5. Checking NAT rules...');
+    logger.info('5. Checking NAT rules...');
     const natIssues = await this.checkNATRules();
     issues.push(...natIssues);
 
@@ -108,12 +107,10 @@ export class RoutingDiagnosticsResource {
       ? `Found ${warningCount} warnings that may affect routing`
       : 'No major routing issues detected';
 
-    console.log('\n========================================');
-    console.log('  Diagnostic Summary');
-    console.log('========================================');
-    console.log(`Total issues found: ${issues.length}`);
-    console.log(`Critical: ${criticalCount}, Warnings: ${warningCount}`);
-    console.log(`Auto-fix available: ${canAutoFix ? 'Yes' : 'No'}`);
+    logger.info('Diagnostic Summary');
+    logger.info(`Total issues found: ${issues.length}`);
+    logger.info(`Critical: ${criticalCount}, Warnings: ${warningCount}`);
+    logger.info(`Auto-fix available: ${canAutoFix ? 'Yes' : 'No'}`);
 
     return {
       timestamp,
@@ -160,16 +157,16 @@ export class RoutingDiagnosticsResource {
               fixCommand: `enable_intervlan_routing_on_interface("${iface.name}")`
             });
 
-            console.log(`  ❌ ${iface.name}: Blocking private networks (blockpriv=${blockPriv}, blockbogons=${blockBogons})`);
+            logger.warn(`${iface.name}: Blocking private networks (blockpriv=${blockPriv}, blockbogons=${blockBogons})`);
           } else {
-            console.log(`  ✅ ${iface.name}: Not blocking private networks`);
+            logger.info(`${iface.name}: Not blocking private networks`);
           }
         } else {
-          console.log(`  ⚠️  ${iface.name}: Unable to retrieve configuration`);
+          logger.warn(`${iface.name}: Unable to retrieve configuration`);
         }
       }
     } catch (error) {
-      console.error('Error checking interface blocking:', error);
+      logger.error('Error checking interface blocking:', error);
       issues.push({
         severity: 'warning',
         component: 'Interface',
@@ -209,9 +206,9 @@ export class RoutingDiagnosticsResource {
             fixAvailable: true,
             fixCommand: 'enable_system_intervlan_routing()'
           });
-          console.log(`  ❌ System: Blocking private networks at system level`);
+          logger.warn('System: Blocking private networks at system level');
         } else {
-          console.log(`  ✅ System: Not blocking private networks`);
+          logger.info('System: Not blocking private networks');
         }
 
         if (!allowInterLan) {
@@ -223,11 +220,11 @@ export class RoutingDiagnosticsResource {
             fixAvailable: true,
             fixCommand: 'enable_system_intervlan_routing()'
           });
-          console.log(`  ⚠️  System: Inter-LAN traffic not explicitly allowed`);
+          logger.warn('System: Inter-LAN traffic not explicitly allowed');
         }
       }
     } catch (error) {
-      console.error('Error checking system settings:', error);
+      logger.error('Error checking system settings:', error);
       issues.push({
         severity: 'warning',
         component: 'System',
@@ -273,9 +270,9 @@ export class RoutingDiagnosticsResource {
           fixAvailable: true,
           fixCommand: `create_intervlan_rule("${sourceNetwork}", "${destNetwork}")`
         });
-        console.log(`  ❌ Firewall: No allow rule from ${sourceNetwork} to ${destNetwork}`);
+        logger.warn(`Firewall: No allow rule from ${sourceNetwork} to ${destNetwork}`);
       } else {
-        console.log(`  ✅ Firewall: Allow rule exists from ${sourceNetwork} to ${destNetwork}`);
+        logger.info(`Firewall: Allow rule exists from ${sourceNetwork} to ${destNetwork}`);
       }
 
       // Check for blocking rules
@@ -298,10 +295,10 @@ export class RoutingDiagnosticsResource {
           },
           fixAvailable: false
         });
-        console.log(`  ❌ Firewall: Blocking rule preventing traffic (${blockingRule.description})`);
+        logger.warn(`Firewall: Blocking rule preventing traffic (${blockingRule.description})`);
       }
     } catch (error) {
-      console.error('Error checking firewall rules:', error);
+      logger.error('Error checking firewall rules:', error);
       issues.push({
         severity: 'warning',
         component: 'Firewall',
@@ -337,9 +334,9 @@ export class RoutingDiagnosticsResource {
             details: { routes: routes.length },
             fixAvailable: false
           });
-          console.log(`  ⚠️  Routing: No default route found`);
+          logger.warn('Routing: No default route found');
         } else {
-          console.log(`  ✅ Routing: Default route present`);
+          logger.info('Routing: Default route present');
         }
 
         // Check for routes to private networks
@@ -347,12 +344,12 @@ export class RoutingDiagnosticsResource {
         for (const network of privateNetworks) {
           const hasRoute = routes.some(r => r.destination.startsWith(network.split('/')[0]));
           if (!hasRoute && network.startsWith('10.')) {
-            console.log(`  ⚠️  Routing: No explicit route for ${network}`);
+            logger.warn(`Routing: No explicit route for ${network}`);
           }
         }
       }
     } catch (error) {
-      console.log(`  ℹ️  Routing: Unable to retrieve routing table via API`);
+      logger.debug('Routing: Unable to retrieve routing table via API');
       // This is not critical as routing table might not be available via API
     }
 
@@ -390,13 +387,13 @@ export class RoutingDiagnosticsResource {
             },
             fixAvailable: false
           });
-          console.log(`  ⚠️  NAT: Rule may be translating internal traffic`);
+          logger.warn('NAT: Rule may be translating internal traffic');
         } else {
-          console.log(`  ✅ NAT: No problematic NAT rules found`);
+          logger.info('NAT: No problematic NAT rules found');
         }
       }
     } catch (error) {
-      console.log(`  ℹ️  NAT: Unable to check NAT rules`);
+      logger.debug('NAT: Unable to check NAT rules');
       // Not critical - NAT might not be the issue
     }
 
@@ -440,15 +437,13 @@ export class RoutingDiagnosticsResource {
    * Automatically fix all detected routing issues
    */
   async fixAllRoutingIssues(): Promise<{ success: boolean; actions: string[] }> {
-    console.log('\n========================================');
-    console.log('  Auto-Fixing Inter-VLAN Routing Issues');
-    console.log('========================================\n');
+    logger.info('Auto-Fixing Inter-VLAN Routing Issues');
 
     const actions: string[] = [];
     let success = true;
 
     // 1. Fix interface blocking
-    console.log('1. Fixing interface blocking settings...');
+    logger.info('1. Fixing interface blocking settings...');
     try {
       const interfaces = await this.interfaceResource.listOverview();
       for (const iface of interfaces) {
@@ -456,46 +451,45 @@ export class RoutingDiagnosticsResource {
           const result = await this.interfaceResource.enableInterVLANRoutingOnInterface(iface.name);
           if (result) {
             actions.push(`Enabled inter-VLAN routing on interface ${iface.name}`);
-            console.log(`   ✅ Fixed ${iface.name}`);
+            logger.info(`Fixed ${iface.name}`);
           } else {
-            console.log(`   ⚠️  Could not fix ${iface.name}`);
+            logger.warn(`Could not fix ${iface.name}`);
           }
         }
       }
     } catch (error) {
-      console.error('   ❌ Error fixing interfaces:', error);
+      logger.error('Error fixing interfaces:', error);
       success = false;
     }
 
     // 2. Fix system settings
-    console.log('\n2. Fixing system-level settings...');
+    logger.info('2. Fixing system-level settings...');
     try {
       const result = await this.systemResource.enableInterVLANRouting();
       if (result) {
         actions.push('Enabled inter-VLAN routing at system level');
-        console.log('   ✅ System settings fixed');
+        logger.info('System settings fixed');
       } else {
-        console.log('   ⚠️  Could not fix system settings');
+        logger.warn('Could not fix system settings');
       }
     } catch (error) {
-      console.error('   ❌ Error fixing system settings:', error);
+      logger.error('Error fixing system settings:', error);
       success = false;
     }
 
     // 3. Apply all changes
-    console.log('\n3. Applying configuration changes...');
+    logger.info('3. Applying configuration changes...');
     try {
       await this.applyAllChanges();
       actions.push('Applied all configuration changes');
-      console.log('   ✅ Changes applied');
+      logger.info('Changes applied');
     } catch (error) {
-      console.error('   ❌ Error applying changes:', error);
+      logger.error('Error applying changes:', error);
       success = false;
     }
 
-    console.log('\n========================================');
-    console.log(`Fix ${success ? 'completed successfully' : 'encountered errors'}`);
-    console.log(`Actions taken: ${actions.length}`);
+    logger.info(`Fix ${success ? 'completed successfully' : 'encountered errors'}`);
+    logger.info(`Actions taken: ${actions.length}`);
 
     return { success, actions };
   }
@@ -516,12 +510,12 @@ export class RoutingDiagnosticsResource {
       try {
         await this.client.post(endpoint, endpoint.includes('configctl') ? { action: 'filter reload' } : {});
         if (this.debugMode) {
-          console.log(`Applied changes via ${endpoint}`);
+          logger.debug(`Applied changes via ${endpoint}`);
         }
       } catch (error) {
         // Some endpoints might not exist, that's OK
         if (this.debugMode) {
-          console.log(`${endpoint} not available`);
+          logger.debug(`${endpoint} not available`);
         }
       }
     }
@@ -534,7 +528,7 @@ export class RoutingDiagnosticsResource {
    * Create specific inter-VLAN routing rules
    */
   async createInterVLANRules(sourceNetwork: string, destNetwork: string, bidirectional: boolean = true): Promise<boolean> {
-    console.log(`\nCreating inter-VLAN rules between ${sourceNetwork} and ${destNetwork}...`);
+    logger.info(`Creating inter-VLAN rules between ${sourceNetwork} and ${destNetwork}...`);
 
     try {
       // Create forward rule
@@ -552,7 +546,7 @@ export class RoutingDiagnosticsResource {
       });
 
       if (forwardRule) {
-        console.log(`✅ Created forward rule: ${sourceNetwork} → ${destNetwork}`);
+        logger.info(`Created forward rule: ${sourceNetwork} -> ${destNetwork}`);
       }
 
       // Create reverse rule if bidirectional
@@ -571,17 +565,17 @@ export class RoutingDiagnosticsResource {
         });
 
         if (reverseRule) {
-          console.log(`✅ Created reverse rule: ${destNetwork} → ${sourceNetwork}`);
+          logger.info(`Created reverse rule: ${destNetwork} -> ${sourceNetwork}`);
         }
       }
 
       // Apply changes
       await this.firewallResource.applyChanges();
-      console.log('✅ Firewall rules applied');
+      logger.info('Firewall rules applied');
 
       return true;
     } catch (error) {
-      console.error('❌ Error creating inter-VLAN rules:', error);
+      logger.error('Error creating inter-VLAN rules:', error);
       return false;
     }
   }
@@ -590,24 +584,22 @@ export class RoutingDiagnosticsResource {
    * Quick fix for DMZ to LAN routing
    */
   async fixDMZRouting(): Promise<boolean> {
-    console.log('\n========================================');
-    console.log('  Quick Fix: DMZ to LAN Routing');
-    console.log('========================================\n');
+    logger.info('Quick Fix: DMZ to LAN Routing');
 
     // 1. Fix opt8 (DMZ) interface
-    console.log('1. Configuring DMZ interface (opt8)...');
+    logger.info('1. Configuring DMZ interface (opt8)...');
     const dmzFixed = await this.interfaceResource.configureDMZInterface('opt8');
     
     // 2. Fix system settings
-    console.log('2. Enabling system inter-VLAN routing...');
+    logger.info('2. Enabling system inter-VLAN routing...');
     const systemFixed = await this.systemResource.enableInterVLANRouting();
     
     // 3. Create firewall rules
-    console.log('3. Creating DMZ to LAN firewall rules...');
+    logger.info('3. Creating DMZ to LAN firewall rules...');
     const rulesCreated = await this.createInterVLANRules('10.0.6.0/24', '10.0.0.0/24');
     
     // 4. Create NFS-specific rules
-    console.log('4. Creating NFS access rules...');
+    logger.info('4. Creating NFS access rules...');
     const nfsRules = await this.firewallResource.createNFSRules({
       interface: 'opt8',
       sourceNetwork: '10.0.6.0/24',
@@ -615,20 +607,15 @@ export class RoutingDiagnosticsResource {
     });
     
     // 5. Apply all changes
-    console.log('5. Applying all changes...');
+    logger.info('5. Applying all changes...');
     await this.applyAllChanges();
     
     const success = dmzFixed && systemFixed && rulesCreated && (!!nfsRules?.tcp || !!nfsRules?.udp);
     
-    console.log('\n========================================');
-    console.log(success ? '✅ DMZ routing fix completed!' : '⚠️  Some fixes failed');
-    console.log('========================================');
-    
+    logger.info(success ? 'DMZ routing fix completed' : 'Some fixes failed');
+
     if (success) {
-      console.log('\nTest connectivity from DMZ (10.0.6.2):');
-      console.log('  ping 10.0.0.14          # Test basic connectivity');
-      console.log('  showmount -e 10.0.0.14  # Test NFS access');
-      console.log('  mount -t nfs 10.0.0.14:/mnt/tank/kubernetes /mnt/test');
+      logger.info('Test connectivity from DMZ (10.0.6.2): ping 10.0.0.14, showmount -e 10.0.0.14');
     }
     
     return success;

--- a/src/resources/firewall/nat.ts
+++ b/src/resources/firewall/nat.ts
@@ -4,6 +4,7 @@ import { OPNSenseAPIClient } from '../../api/client.js';
 import { InterfaceMapper } from '../../utils/interface-mapper.js';
 import SSHExecutor from '../ssh/executor.js';
 import { parseStringPromise, Builder } from 'xml2js';
+import { logger } from '../../utils/logger.js';
 
 // NAT Rule Types
 export interface OutboundNATRule {
@@ -84,11 +85,11 @@ export class NATResource {
       this.sshExecutor = new SSHExecutor();
       this.useSSH = true;
       if (this.debugMode) {
-        console.log('[NATResource] SSH configured, using SSH/CLI for NAT management');
+        logger.debug('[NATResource] SSH configured, using SSH/CLI for NAT management');
       }
     } else {
       if (this.debugMode) {
-        console.log('[NATResource] SSH not configured, limited NAT functionality available');
+        logger.debug('[NATResource] SSH not configured, limited NAT functionality available');
       }
     }
   }
@@ -174,11 +175,11 @@ export class NATResource {
    */
   async listOutboundRules(): Promise<OutboundNATRule[]> {
     if (this.debugMode) {
-      console.log('[NATResource] Fetching outbound NAT rules via SSH');
+      logger.debug('[NATResource] Fetching outbound NAT rules via SSH');
     }
 
     if (!this.sshExecutor) {
-      console.warn('[NATResource] SSH not configured, returning empty list');
+      logger.warn('[NATResource] SSH not configured, returning empty list');
       return [];
     }
 
@@ -188,7 +189,7 @@ export class NATResource {
       const outbound = natConfig.outbound || {};
       
       if (this.debugMode) {
-        console.log('[NATResource] Outbound NAT mode:', outbound.mode);
+        logger.debug('[NATResource] Outbound NAT mode:', outbound.mode);
       }
 
       // Handle rules - they might be an array or object
@@ -203,12 +204,12 @@ export class NATResource {
       }
 
       if (this.debugMode) {
-        console.log(`[NATResource] Found ${rules.length} outbound NAT rules`);
+        logger.debug(`[NATResource] Found ${rules.length} outbound NAT rules`);
       }
 
       return rules;
     } catch (error) {
-      console.error('Failed to list outbound NAT rules:', error);
+      logger.error('Failed to list outbound NAT rules:', error);
       return [];
     }
   }
@@ -218,7 +219,7 @@ export class NATResource {
    */
   async getOutboundMode(): Promise<NATMode> {
     if (!this.sshExecutor) {
-      console.warn('[NATResource] SSH not configured, returning default mode');
+      logger.warn('[NATResource] SSH not configured, returning default mode');
       return 'automatic';
     }
 
@@ -227,7 +228,7 @@ export class NATResource {
       const mode = config.nat?.outbound?.mode || 'automatic';
       return mode as NATMode;
     } catch (error) {
-      console.error('Failed to get outbound NAT mode:', error);
+      logger.error('Failed to get outbound NAT mode:', error);
       return 'automatic';
     }
   }
@@ -237,7 +238,7 @@ export class NATResource {
    */
   async setOutboundMode(mode: NATMode): Promise<boolean> {
     if (this.debugMode) {
-      console.log(`[NATResource] Setting outbound NAT mode to: ${mode}`);
+      logger.debug(`[NATResource] Setting outbound NAT mode to: ${mode}`);
     }
 
     if (!this.sshExecutor) {
@@ -259,7 +260,7 @@ export class NATResource {
       
       return true;
     } catch (error) {
-      console.error('Failed to set outbound NAT mode:', error);
+      logger.error('Failed to set outbound NAT mode:', error);
       return false;
     }
   }
@@ -269,7 +270,7 @@ export class NATResource {
    */
   async createOutboundRule(rule: OutboundNATRule): Promise<{ uuid: string; success: boolean }> {
     if (this.debugMode) {
-      console.log('[NATResource] Creating outbound NAT rule via SSH:', rule);
+      logger.debug('[NATResource] Creating outbound NAT rule via SSH:', rule);
     }
 
     if (!this.sshExecutor) {
@@ -329,7 +330,7 @@ export class NATResource {
       
       return { uuid, success: true };
     } catch (error) {
-      console.error('Failed to create outbound NAT rule:', error);
+      logger.error('Failed to create outbound NAT rule:', error);
       throw error;
     }
   }
@@ -371,7 +372,7 @@ export class NATResource {
       
       return true;
     } catch (error) {
-      console.error('Failed to delete outbound NAT rule:', error);
+      logger.error('Failed to delete outbound NAT rule:', error);
       throw error;
     }
   }
@@ -381,7 +382,7 @@ export class NATResource {
    */
   async updateOutboundRule(uuid: string, updates: Partial<OutboundNATRule>): Promise<boolean> {
     // For SSH implementation, we would need to identify rules by description or other fields
-    console.warn('[NATResource] Update via SSH not fully implemented. Use delete and create instead.');
+    logger.warn('[NATResource] Update via SSH not fully implemented. Use delete and create instead.');
     return false;
   }
 
@@ -389,7 +390,7 @@ export class NATResource {
    * Toggle outbound rule enabled/disabled (placeholder for SSH implementation)
    */
   async toggleOutboundRule(uuid: string, enabled?: string): Promise<boolean> {
-    console.warn('[NATResource] Toggle via SSH not fully implemented');
+    logger.warn('[NATResource] Toggle via SSH not fully implemented');
     return false;
   }
 
@@ -397,7 +398,7 @@ export class NATResource {
    * Get a specific outbound NAT rule (placeholder for SSH implementation)
    */
   async getOutboundRule(uuid: string): Promise<OutboundNATRule | null> {
-    console.warn('[NATResource] Get specific rule via SSH not implemented');
+    logger.warn('[NATResource] Get specific rule via SSH not implemented');
     return null;
   }
 
@@ -408,11 +409,11 @@ export class NATResource {
    */
   async listPortForwards(): Promise<PortForwardRule[]> {
     if (this.debugMode) {
-      console.log('[NATResource] Fetching port forward rules via SSH');
+      logger.debug('[NATResource] Fetching port forward rules via SSH');
     }
 
     if (!this.sshExecutor) {
-      console.warn('[NATResource] SSH not configured, returning empty list');
+      logger.warn('[NATResource] SSH not configured, returning empty list');
       return [];
     }
 
@@ -433,12 +434,12 @@ export class NATResource {
       }
 
       if (this.debugMode) {
-        console.log(`[NATResource] Found ${rules.length} port forward rules`);
+        logger.debug(`[NATResource] Found ${rules.length} port forward rules`);
       }
 
       return rules;
     } catch (error) {
-      console.error('Failed to list port forward rules:', error);
+      logger.error('Failed to list port forward rules:', error);
       return [];
     }
   }
@@ -448,7 +449,7 @@ export class NATResource {
    */
   async createPortForward(rule: PortForwardRule): Promise<{ uuid: string; success: boolean }> {
     if (this.debugMode) {
-      console.log('[NATResource] Creating port forward rule via SSH:', rule);
+      logger.debug('[NATResource] Creating port forward rule via SSH:', rule);
     }
 
     if (!this.sshExecutor) {
@@ -522,12 +523,12 @@ export class NATResource {
       await this.applyNATChanges();
 
       if (this.debugMode) {
-        console.log(`[NATResource] Port forward created successfully: ${uuid}`);
+        logger.debug(`[NATResource] Port forward created successfully: ${uuid}`);
       }
 
       return { uuid, success: true };
     } catch (error) {
-      console.error('Failed to create port forward rule:', error);
+      logger.error('Failed to create port forward rule:', error);
       throw error;
     }
   }
@@ -537,7 +538,7 @@ export class NATResource {
    */
   async deletePortForward(identifier: string): Promise<boolean> {
     if (this.debugMode) {
-      console.log('[NATResource] Deleting port forward rule:', identifier);
+      logger.debug('[NATResource] Deleting port forward rule:', identifier);
     }
 
     if (!this.sshExecutor) {
@@ -580,12 +581,12 @@ export class NATResource {
       await this.applyNATChanges();
 
       if (this.debugMode) {
-        console.log(`[NATResource] Port forward deleted successfully`);
+        logger.debug(`[NATResource] Port forward deleted successfully`);
       }
 
       return true;
     } catch (error) {
-      console.error('Failed to delete port forward rule:', error);
+      logger.error('Failed to delete port forward rule:', error);
       throw error;
     }
   }
@@ -638,8 +639,8 @@ export class NATResource {
     lanNetwork?: string;
     otherInternalNetworks?: string[];
   }): Promise<{ success: boolean; message: string; rulesCreated: string[] }> {
-    console.log('\n[NATResource] Starting DMZ NAT fix...');
-    
+    logger.info('[NATResource] Starting DMZ NAT fix...');
+
     const dmzNetwork = params?.dmzNetwork || '10.0.6.0/24';
     const lanNetwork = params?.lanNetwork || '10.0.0.0/24';
     const otherNetworks = params?.otherInternalNetworks || [
@@ -652,18 +653,18 @@ export class NATResource {
     try {
       // Step 1: Check current NAT mode
       const currentMode = await this.getOutboundMode();
-      console.log(`Current NAT mode: ${currentMode}`);
+      logger.info(`Current NAT mode: ${currentMode}`);
 
       // Step 2: Set to hybrid mode if needed (allows manual rules with automatic)
       if (currentMode === 'automatic') {
-        console.log('Switching NAT mode from automatic to hybrid...');
+        logger.info('Switching NAT mode from automatic to hybrid...');
         await this.setOutboundMode('hybrid');
       }
 
       // Step 3: Create no-NAT exception rules for inter-VLAN traffic
-      
+
       // DMZ to LAN - No NAT
-      console.log('Creating DMZ to LAN no-NAT rule...');
+      logger.info('Creating DMZ to LAN no-NAT rule...');
       const dmzToLan = await this.createOutboundRule({
         enabled: '1',
         interface: 'wan',
@@ -676,7 +677,7 @@ export class NATResource {
       rulesCreated.push(`DMZ→LAN`);
 
       // LAN to DMZ - No NAT (return traffic)
-      console.log('Creating LAN to DMZ no-NAT rule...');
+      logger.info('Creating LAN to DMZ no-NAT rule...');
       const lanToDmz = await this.createOutboundRule({
         enabled: '1',
         interface: 'wan',
@@ -690,7 +691,7 @@ export class NATResource {
 
       // DMZ to other internal networks
       for (const network of otherNetworks) {
-        console.log(`Creating DMZ to ${network} no-NAT rule...`);
+        logger.info(`Creating DMZ to ${network} no-NAT rule...`);
         await this.createOutboundRule({
           enabled: '1',
           interface: 'wan',
@@ -716,16 +717,16 @@ export class NATResource {
       }
 
       // Step 4: Apply all NAT changes
-      console.log('Applying NAT configuration...');
+      logger.info('Applying NAT configuration...');
       await this.applyNATChanges();
 
       // Step 5: Verify the rules were created
       const rules = await this.listOutboundRules();
       const mcpRules = rules.filter(r => r.description?.includes('MCP auto-fix'));
-      
-      console.log(`\n✅ DMZ NAT fix completed successfully!`);
-      console.log(`Created ${rulesCreated.length} no-NAT exception rules`);
-      console.log(`Verified ${mcpRules.length} MCP rules in configuration`);
+
+      logger.info('DMZ NAT fix completed successfully');
+      logger.info(`Created ${rulesCreated.length} no-NAT exception rules`);
+      logger.info(`Verified ${mcpRules.length} MCP rules in configuration`);
 
       return {
         success: true,
@@ -734,7 +735,7 @@ export class NATResource {
       };
 
     } catch (error) {
-      console.error('Failed to fix DMZ NAT:', error);
+      logger.error('Failed to fix DMZ NAT:', error);
       return {
         success: false,
         message: `Failed to fix DMZ NAT: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -747,7 +748,7 @@ export class NATResource {
    * Quick fix for DMZ NAT issue with minimal configuration
    */
   async quickFixDMZNAT(): Promise<{ success: boolean; message: string }> {
-    console.log('\n[NATResource] Quick DMZ NAT fix...');
+    logger.info('[NATResource] Quick DMZ NAT fix...');
     
     try {
       // Set to hybrid mode
@@ -791,7 +792,7 @@ export class NATResource {
    * Remove all MCP-created NAT fix rules
    */
   async cleanupDMZNATFix(): Promise<{ success: boolean; deletedCount: number }> {
-    console.log('\n[NATResource] Cleaning up MCP NAT fix rules...');
+    logger.info('[NATResource] Cleaning up MCP NAT fix rules...');
     
     try {
       const rules = await this.listOutboundRules();
@@ -803,7 +804,7 @@ export class NATResource {
       let deletedCount = 0;
       for (const rule of mcpRules) {
         if (rule.description) {
-          console.log(`Deleting rule: ${rule.description}`);
+          logger.info(`Deleting rule: ${rule.description}`);
           await this.deleteOutboundRule(rule.description);
           deletedCount++;
         }
@@ -815,7 +816,7 @@ export class NATResource {
 
       return { success: true, deletedCount };
     } catch (error) {
-      console.error('Cleanup failed:', error);
+      logger.error('Cleanup failed:', error);
       return { success: false, deletedCount: 0 };
     }
   }
@@ -836,7 +837,7 @@ export class NATResource {
       npt: number;
     };
   }> {
-    console.log('\n[NATResource] Analyzing NAT configuration...');
+    logger.info('[NATResource] Analyzing NAT configuration...');
 
     const issues: string[] = [];
     const recommendations: string[] = [];
@@ -907,7 +908,7 @@ export class NATResource {
    */
   async applyNATChanges(): Promise<any> {
     if (this.debugMode) {
-      console.log('[NATResource] Applying NAT changes...');
+      logger.debug('[NATResource] Applying NAT changes...');
     }
 
     if (this.sshExecutor) {
@@ -923,7 +924,7 @@ export class NATResource {
         const response = await this.client.post('/firewall/nat/apply');
         return response;
       } catch (error) {
-        console.error('Failed to apply NAT changes via API:', error);
+        logger.error('Failed to apply NAT changes via API:', error);
         throw new Error('Cannot apply NAT changes without SSH access');
       }
     }

--- a/src/resources/firewall/rule.ts
+++ b/src/resources/firewall/rule.ts
@@ -1,6 +1,7 @@
 // Firewall Rule Resource Implementation
 import { OPNSenseAPIClient } from '../../api/client.js';
 import { InterfaceMapper } from '../../utils/interface-mapper.js';
+import { logger } from '../../utils/logger.js';
 
 export interface FirewallRule {
   uuid?: string;
@@ -41,7 +42,7 @@ export class FirewallRuleResource {
    */
   async list(): Promise<FirewallRule[]> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Starting list() operation');
+      logger.debug('[FirewallRuleResource] Starting list() operation');
     }
 
     try {
@@ -49,19 +50,19 @@ export class FirewallRuleResource {
       const allRules = await this.getAllRules();
 
       if (this.debugMode) {
-        console.log(`[FirewallRuleResource] getAllRules() returned ${allRules.length} rules`);
+        logger.debug(`[FirewallRuleResource] getAllRules() returned ${allRules.length} rules`);
       }
 
       // If no rules found from the automation API, try legacy pf rule stats
       // Many users configure rules via the GUI which only creates legacy pf rules
       if (allRules.length === 0) {
         if (this.debugMode) {
-          console.log('[FirewallRuleResource] No automation rules found, trying legacy pf rules');
+          logger.debug('[FirewallRuleResource] No automation rules found, trying legacy pf rules');
         }
         const legacyRules = await this.getLegacyRules();
         if (legacyRules.length > 0) {
           if (this.debugMode) {
-            console.log(`[FirewallRuleResource] Found ${legacyRules.length} legacy pf rules`);
+            logger.debug(`[FirewallRuleResource] Found ${legacyRules.length} legacy pf rules`);
           }
           return legacyRules;
         }
@@ -83,7 +84,7 @@ export class FirewallRuleResource {
 
       return allRules;
     } catch (error) {
-      console.error('Error listing firewall rules:', error);
+      logger.error('Error listing firewall rules:', error);
 
       // Try legacy rules as fallback
       try {
@@ -93,13 +94,13 @@ export class FirewallRuleResource {
         }
       } catch (legacyError) {
         if (this.debugMode) {
-          console.log('[FirewallRuleResource] Legacy rules fallback also failed:', legacyError);
+          logger.debug('[FirewallRuleResource] Legacy rules fallback also failed:', legacyError);
         }
       }
 
       // Return cached rules as last resort
       if (this.rulesCache.size > 0) {
-        console.log('Returning cached rules due to API error');
+        logger.info('Returning cached rules due to API error');
         return Array.from(this.rulesCache.values());
       }
     }
@@ -112,23 +113,23 @@ export class FirewallRuleResource {
    */
   async get(uuid: string): Promise<FirewallRule | null> {
     if (this.debugMode) {
-      console.log(`[FirewallRuleResource] Getting rule ${uuid}`);
+      logger.debug(`[FirewallRuleResource] Getting rule ${uuid}`);
     }
     
     try {
       const response = await this.client.get(`/firewall/filter/getRule/${uuid}`);
       if (response?.rule) {
         if (this.debugMode) {
-          console.log(`[FirewallRuleResource] Rule ${uuid} found:`, response.rule);
+          logger.debug(`[FirewallRuleResource] Rule ${uuid} found:`, response.rule);
         }
         return { uuid, ...response.rule };
       }
     } catch (error) {
-      console.warn(`Could not get rule ${uuid}:`, error);
+      logger.warn(`Could not get rule ${uuid}:`, error);
     }
     
     if (this.debugMode) {
-      console.log(`[FirewallRuleResource] Rule ${uuid} not found`);
+      logger.debug(`[FirewallRuleResource] Rule ${uuid} not found`);
     }
     return null;
   }
@@ -139,14 +140,14 @@ export class FirewallRuleResource {
    */
   async getAllRules(): Promise<FirewallRule[]> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Fetching all rules via /firewall/filter/get');
+      logger.debug('[FirewallRuleResource] Fetching all rules via /firewall/filter/get');
     }
     
     try {
       const response = await this.client.get('/firewall/filter/get');
       
       if (this.debugMode) {
-        console.log('[FirewallRuleResource] /firewall/filter/get response structure:', {
+        logger.debug('[FirewallRuleResource] /firewall/filter/get response structure:', {
           hasFilter: !!response?.filter,
           hasRules: !!response?.filter?.rules,
           hasRulesRule: !!response?.filter?.rules?.rule,
@@ -185,7 +186,7 @@ export class FirewallRuleResource {
           });
           
           if (this.debugMode) {
-            console.log(`[FirewallRuleResource] Converted ${rulesArray.length} rules from filter.rules.rule`);
+            logger.debug(`[FirewallRuleResource] Converted ${rulesArray.length} rules from filter.rules.rule`);
           }
           
           return rulesArray;
@@ -194,7 +195,7 @@ export class FirewallRuleResource {
         // If already an array (unlikely), return it
         if (Array.isArray(rulesObj)) {
           if (this.debugMode) {
-            console.log(`[FirewallRuleResource] Rules already in array format: ${rulesObj.length} rules`);
+            logger.debug(`[FirewallRuleResource] Rules already in array format: ${rulesObj.length} rules`);
           }
           return rulesObj;
         }
@@ -219,13 +220,13 @@ export class FirewallRuleResource {
         
         if (rulesArray.length > 0) {
           if (this.debugMode) {
-            console.log(`[FirewallRuleResource] Found ${rulesArray.length} rules at filter.rules`);
+            logger.debug(`[FirewallRuleResource] Found ${rulesArray.length} rules at filter.rules`);
           }
           return rulesArray;
         }
       }
     } catch (error) {
-      console.warn('Could not fetch all rules via get endpoint:', error);
+      logger.warn('Could not fetch all rules via get endpoint:', error);
     }
     
     return [];
@@ -238,7 +239,7 @@ export class FirewallRuleResource {
    */
   async getLegacyRules(): Promise<FirewallRule[]> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Fetching legacy pf rules');
+      logger.debug('[FirewallRuleResource] Fetching legacy pf rules');
     }
 
     const rules: FirewallRule[] = [];
@@ -277,7 +278,7 @@ export class FirewallRuleResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log('[FirewallRuleResource] filter_util/ruleStats failed:', error);
+        logger.debug('[FirewallRuleResource] filter_util/ruleStats failed:', error);
       }
     }
 
@@ -316,13 +317,13 @@ export class FirewallRuleResource {
         }
       } catch (error) {
         if (this.debugMode) {
-          console.log('[FirewallRuleResource] searchRule fallback also failed:', error);
+          logger.debug('[FirewallRuleResource] searchRule fallback also failed:', error);
         }
       }
     }
 
     if (this.debugMode) {
-      console.log(`[FirewallRuleResource] Legacy rules: found ${rules.length} total`);
+      logger.debug(`[FirewallRuleResource] Legacy rules: found ${rules.length} total`);
     }
 
     return rules;
@@ -370,7 +371,7 @@ export class FirewallRuleResource {
         this.interfacesLoaded = true;
       }
     } catch (error) {
-      console.warn('Failed to load interface mappings, using defaults');
+      logger.warn('Failed to load interface mappings, using defaults');
     }
   }
 
@@ -379,7 +380,7 @@ export class FirewallRuleResource {
    */
   async create(rule: FirewallRule): Promise<{ uuid: string; success: boolean }> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Creating rule:', rule);
+      logger.debug('[FirewallRuleResource] Creating rule:', rule);
     }
     
     // Ensure interface mappings are loaded
@@ -392,11 +393,11 @@ export class FirewallRuleResource {
     mappedRule.protocol = InterfaceMapper.mapProtocol(rule.protocol);
     
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Interface mapping:', {
+      logger.debug('[FirewallRuleResource] Interface mapping:', {
         original: originalInterface,
         mapped: mappedRule.interface
       });
-      console.log('[FirewallRuleResource] Protocol mapping:', {
+      logger.debug('[FirewallRuleResource] Protocol mapping:', {
         original: rule.protocol,
         mapped: mappedRule.protocol
       });
@@ -429,13 +430,13 @@ export class FirewallRuleResource {
 
     // Add the rule
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Sending addRule request:', { rule: ruleData });
+      logger.debug('[FirewallRuleResource] Sending addRule request:', { rule: ruleData });
     }
     
     const response = await this.client.post('/firewall/filter/addRule', { rule: ruleData });
     
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] addRule response:', response);
+      logger.debug('[FirewallRuleResource] addRule response:', response);
     }
     
     if (response.uuid) {
@@ -454,12 +455,12 @@ export class FirewallRuleResource {
       try {
         const refreshedRules = await this.getAllRules();
         if (this.debugMode) {
-          console.log(`[FirewallRuleResource] After refresh, total rules: ${refreshedRules.length}`);
+          logger.debug(`[FirewallRuleResource] After refresh, total rules: ${refreshedRules.length}`);
           const foundInList = refreshedRules.some(r => r.uuid === response.uuid);
-          console.log(`[FirewallRuleResource] New rule ${response.uuid} found in list: ${foundInList}`);
+          logger.debug(`[FirewallRuleResource] New rule ${response.uuid} found in list: ${foundInList}`);
         }
       } catch (refreshError) {
-        console.warn('Could not refresh rules after creation:', refreshError);
+        logger.warn('Could not refresh rules after creation:', refreshError);
       }
       
       // Verify the rule was created successfully
@@ -467,21 +468,21 @@ export class FirewallRuleResource {
       if (verifyRule) {
         // Update cache with verified rule
         this.rulesCache.set(response.uuid, verifyRule);
-        console.log(`Rule ${response.uuid} created and verified successfully`);
+        logger.info(`Rule ${response.uuid} created and verified successfully`);
         
         // Double-check it appears in the list
         const allRules = await this.list();
         const inList = allRules.some(r => r.uuid === response.uuid);
         
         if (!inList) {
-          console.warn(`WARNING: Rule ${response.uuid} exists individually but not in list!`);
-          console.warn('This may indicate a persistence issue. Attempting additional apply...');
+          logger.warn(`Rule ${response.uuid} exists individually but not in list!`);
+          logger.warn('This may indicate a persistence issue. Attempting additional apply...');
           
           // Try additional apply methods
           await this.forceApply();
         }
       } else {
-        console.warn(`Warning: Rule ${response.uuid} was created but could not be verified immediately`);
+        logger.warn(`Rule ${response.uuid} was created but could not be verified immediately`);
       }
       
       return { uuid: response.uuid, success: true };
@@ -540,7 +541,7 @@ export class FirewallRuleResource {
    */
   async applyChanges(): Promise<any> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Starting applyChanges()');
+      logger.debug('[FirewallRuleResource] Starting applyChanges()');
     }
     
     try {
@@ -548,7 +549,7 @@ export class FirewallRuleResource {
       const applyResponse = await this.client.post('/firewall/filter/apply');
       
       if (this.debugMode) {
-        console.log('[FirewallRuleResource] apply response:', applyResponse);
+        logger.debug('[FirewallRuleResource] apply response:', applyResponse);
       }
       
       // Add a delay to allow changes to propagate
@@ -559,18 +560,18 @@ export class FirewallRuleResource {
       try {
         // Try to reconfigure the filter service
         const reconfigureResponse = await this.client.post('/firewall/filter/reconfigure');
-        console.log('Firewall filter reconfigured:', reconfigureResponse);
+        logger.info('Firewall filter reconfigured:', reconfigureResponse);
       } catch (reconfigError) {
         if (this.debugMode) {
-          console.log('[FirewallRuleResource] reconfigure failed, trying savepoint:', reconfigError);
+          logger.debug('[FirewallRuleResource] reconfigure failed, trying savepoint:', reconfigError);
         }
         
         // If reconfigure fails, try the savepoint approach
         try {
           const savepointResponse = await this.client.post('/firewall/filter/savepoint');
-          console.log('Firewall configuration saved via savepoint:', savepointResponse);
+          logger.info('Firewall configuration saved via savepoint:', savepointResponse);
         } catch (savepointError) {
-          console.warn('Could not save firewall configuration:', savepointError);
+          logger.warn('Could not save firewall configuration:', savepointError);
         }
       }
       
@@ -579,7 +580,7 @@ export class FirewallRuleResource {
       
       return applyResponse;
     } catch (error) {
-      console.error('Failed to apply firewall changes:', error);
+      logger.error('Failed to apply firewall changes:', error);
       throw error;
     }
   }
@@ -589,7 +590,7 @@ export class FirewallRuleResource {
    */
   async forceApply(): Promise<void> {
     if (this.debugMode) {
-      console.log('[FirewallRuleResource] Starting forceApply() - trying all apply methods');
+      logger.debug('[FirewallRuleResource] Starting forceApply() - trying all apply methods');
     }
     
     const applyMethods = [
@@ -603,11 +604,11 @@ export class FirewallRuleResource {
     for (const method of applyMethods) {
       try {
         const response = await this.client.post(method.endpoint);
-        console.log(`[FirewallRuleResource] ${method.name} succeeded:`, response);
+        logger.debug(`[FirewallRuleResource] ${method.name} succeeded:`, response);
         await new Promise(resolve => setTimeout(resolve, 500));
       } catch (error: any) {
         if (this.debugMode) {
-          console.log(`[FirewallRuleResource] ${method.name} failed:`, error?.message || error);
+          logger.debug(`[FirewallRuleResource] ${method.name} failed:`, error?.message || error);
         }
       }
     }
@@ -629,18 +630,18 @@ export class FirewallRuleResource {
    * Debug method to discover valid interface names
    */
   async debugInterfaces(): Promise<void> {
-    console.log('\n[FirewallRuleResource] Discovering interfaces...');
-    
+    logger.debug('[FirewallRuleResource] Discovering interfaces...');
+
     try {
       // Method 1: Get from rule options
       const options = await this.getOptions();
       if (options?.interface?.values) {
-        console.log('\nAvailable interfaces from getRule:');
+        logger.debug('Available interfaces from getRule:');
         Object.entries(options.interface.values).forEach(([key, value]: [string, any]) => {
-          console.log(`  ${key}: ${value.value}`);
+          logger.debug(`  ${key}: ${value.value}`);
         });
       }
-      
+
       // Method 2: Try common interface names
       const testInterfaces = [
         'lan', 'wan', 'opt1', 'opt2', 'opt3',
@@ -648,24 +649,24 @@ export class FirewallRuleResource {
         'igc3_vlan6', 'igc3_vlan4', 'igc3_vlan2',
         'vlan6', 'vlan4', 'vlan2'
       ];
-      
-      console.log('\nTesting common interface names:');
+
+      logger.debug('Testing common interface names:');
       for (const iface of testInterfaces) {
         const mapped = this.interfaceMapper.mapInterface(iface);
         if (mapped !== iface) {
-          console.log(`  ${iface} -> ${mapped}`);
+          logger.debug(`  ${iface} -> ${mapped}`);
         }
       }
-      
+
       // Method 3: Get all current mappings
-      console.log('\nCurrent interface mappings:');
+      logger.debug('Current interface mappings:');
       const mappings = this.interfaceMapper.getMappings();
       Object.entries(mappings).forEach(([friendly, internal]) => {
-        console.log(`  ${friendly} -> ${internal}`);
+        logger.debug(`  ${friendly} -> ${internal}`);
       });
-      
+
     } catch (error) {
-      console.error('Error discovering interfaces:', error);
+      logger.error('Error discovering interfaces:', error);
     }
   }
 
@@ -673,8 +674,8 @@ export class FirewallRuleResource {
    * Test alternative API endpoints
    */
   async testAlternativeEndpoints(): Promise<void> {
-    console.log('\n[FirewallRuleResource] Testing alternative endpoints...');
-    
+    logger.debug('[FirewallRuleResource] Testing alternative endpoints...');
+
     const endpoints = [
       '/firewall/filter/get',
       '/firewall/filter/listRules',
@@ -683,26 +684,24 @@ export class FirewallRuleResource {
       '/firewall/filter/status',
       '/firewall/filter/info'
     ];
-    
+
     for (const endpoint of endpoints) {
       try {
         const response = await this.client.get(endpoint);
-        console.log(`\n${endpoint}:`);
-        console.log('  Success - Response keys:', Object.keys(response || {}));
-        
+        logger.debug(`${endpoint}: Success - Response keys:`, Object.keys(response || {}));
+
         // Check for rules in various places
         if (response?.rules) {
-          console.log('  Found rules at .rules:', Array.isArray(response.rules) ? `Array(${response.rules.length})` : typeof response.rules);
+          logger.debug(`  Found rules at .rules: ${Array.isArray(response.rules) ? `Array(${response.rules.length})` : typeof response.rules}`);
         }
         if (response?.filter?.rules) {
-          console.log('  Found rules at .filter.rules:', Array.isArray(response.filter.rules) ? `Array(${response.filter.rules.length})` : typeof response.filter.rules);
+          logger.debug(`  Found rules at .filter.rules: ${Array.isArray(response.filter.rules) ? `Array(${response.filter.rules.length})` : typeof response.filter.rules}`);
         }
         if (response?.rows) {
-          console.log('  Found rules at .rows:', Array.isArray(response.rows) ? `Array(${response.rows.length})` : typeof response.rows);
+          logger.debug(`  Found rules at .rows: ${Array.isArray(response.rows) ? `Array(${response.rows.length})` : typeof response.rows}`);
         }
       } catch (error: any) {
-        console.log(`\n${endpoint}:`);
-        console.log('  Failed:', error?.message || error);
+        logger.debug(`${endpoint}: Failed:`, error?.message || error);
       }
     }
   }
@@ -858,10 +857,10 @@ export class FirewallRuleResource {
     const sourceNetwork = params.sourceNetwork || '10.0.6.0/24';
     const truenasIP = params.truenasIP || '10.0.0.14';
     
-    console.log(`\n[FirewallRuleResource] Creating NFS rules:`);
-    console.log(`  Interface: ${params.interface}`);
-    console.log(`  Source: ${sourceNetwork}`);
-    console.log(`  Destination: ${truenasIP}`);
+    logger.info('[FirewallRuleResource] Creating NFS rules:');
+    logger.info(`  Interface: ${params.interface}`);
+    logger.info(`  Source: ${sourceNetwork}`);
+    logger.info(`  Destination: ${truenasIP}`);
     
     // Create TCP rule for NFS
     const tcpRule = await this.create({
@@ -881,9 +880,9 @@ export class FirewallRuleResource {
       interface: params.interface
     } as FirewallRule);
     
-    console.log(`\nNFS Rules created:`);
-    console.log(`  TCP Rule UUID: ${tcpRule.uuid}`);
-    console.log(`  UDP Rule UUID: ${udpRule.uuid}`);
+    logger.info('NFS Rules created:');
+    logger.info(`  TCP Rule UUID: ${tcpRule.uuid}`);
+    logger.info(`  UDP Rule UUID: ${udpRule.uuid}`);
     
     return {
       tcp: tcpRule.uuid,
@@ -898,7 +897,7 @@ export class FirewallRuleResource {
     rulesExist: boolean;
     details: any;
   }> {
-    console.log('\n[FirewallRuleResource] Validating NFS connectivity rules...');
+    logger.info('[FirewallRuleResource] Validating NFS connectivity rules...');
     
     const rules = await this.list();
     const nfsRules = rules.filter(r => 
@@ -906,7 +905,7 @@ export class FirewallRuleResource {
       (r.destination_port && (r.destination_port.includes('111') || r.destination_port.includes('2049')))
     );
     
-    console.log(`Found ${nfsRules.length} NFS-related rules`);
+    logger.info(`Found ${nfsRules.length} NFS-related rules`);
     
     const details = {
       totalRules: rules.length,

--- a/src/resources/network/arp.ts
+++ b/src/resources/network/arp.ts
@@ -1,5 +1,6 @@
 // ARP Table Management Resource
 import { OPNSenseAPIClient } from '../../api/client.js';
+import { logger } from '../../utils/logger.js';
 
 export interface ArpEntry {
   ip: string;                // IP address
@@ -35,14 +36,14 @@ export class ArpTableResource {
   async list(): Promise<ArpEntry[]> {
     try {
       if (this.debugMode) {
-        console.log('[ARP] Fetching ARP table...');
+        logger.debug('[ARP] Fetching ARP table...');
       }
 
       // OPNsense exposes ARP table through diagnostics interface
       const response = await this.client.get('/diagnostics/interface/getArp');
 
       if (this.debugMode) {
-        console.log('[ARP] Raw response:', JSON.stringify(response, null, 2));
+        logger.debug('[ARP] Raw response:', JSON.stringify(response, null, 2));
       }
 
       // Handle different response formats
@@ -59,7 +60,7 @@ export class ArpTableResource {
       return entries.map(entry => this.normalizeArpEntry(entry));
     } catch (error) {
       if (this.debugMode) {
-        console.error('[ARP] Failed to fetch ARP table:', error);
+        logger.error('[ARP] Failed to fetch ARP table:', error);
       }
       
       // Try alternative endpoint
@@ -76,7 +77,7 @@ export class ArpTableResource {
         }
       } catch (altError) {
         if (this.debugMode) {
-          console.error('[ARP] Alternative endpoint also failed:', altError);
+          logger.error('[ARP] Alternative endpoint also failed:', altError);
         }
       }
       
@@ -311,7 +312,7 @@ export class ArpTableResource {
       return true;
     } catch (error) {
       if (this.debugMode) {
-        console.error('[ARP] Failed to clear entry:', error);
+        logger.error('[ARP] Failed to clear entry:', error);
       }
       throw new Error(`Failed to clear ARP entry: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -330,7 +331,7 @@ export class ArpTableResource {
       return true;
     } catch (error) {
       if (this.debugMode) {
-        console.error('[ARP] Failed to add static entry:', error);
+        logger.error('[ARP] Failed to add static entry:', error);
       }
       throw new Error(`Failed to add static ARP entry: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/src/resources/network/interfaces.ts
+++ b/src/resources/network/interfaces.ts
@@ -1,6 +1,7 @@
 // Interface Configuration Resource Implementation
 // Manages OPNsense network interface settings including VLAN routing configuration
 import { OPNSenseAPIClient } from '../../api/client.js';
+import { logger } from '../../utils/logger.js';
 
 export interface InterfaceConfig {
   uuid?: string;
@@ -58,7 +59,7 @@ export class InterfaceConfigResource {
    */
   async listOverview(): Promise<InterfaceOverview[]> {
     if (this.debugMode) {
-      console.log('[InterfaceConfig] Getting interface overview');
+      logger.debug('[InterfaceConfig] Getting interface overview');
     }
 
     // Try primary endpoint first (works on older OPNsense versions)
@@ -66,7 +67,7 @@ export class InterfaceConfigResource {
       const response = await this.client.get('/interfaces/overview/list');
 
       if (this.debugMode) {
-        console.log('[InterfaceConfig] Overview response:', {
+        logger.debug('[InterfaceConfig] Overview response:', {
           isArray: Array.isArray(response),
           hasRows: !!response?.rows,
           keys: response ? Object.keys(response) : []
@@ -79,7 +80,7 @@ export class InterfaceConfigResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log('[InterfaceConfig] /interfaces/overview/list failed, trying fallback endpoints');
+        logger.debug('[InterfaceConfig] /interfaces/overview/list failed, trying fallback endpoints');
       }
     }
 
@@ -88,7 +89,7 @@ export class InterfaceConfigResource {
       return await this.listOverviewFromDiagnostics();
     } catch (error) {
       if (this.debugMode) {
-        console.log('[InterfaceConfig] Diagnostics fallback failed:', error);
+        logger.debug('[InterfaceConfig] Diagnostics fallback failed:', error);
       }
     }
 
@@ -101,7 +102,7 @@ export class InterfaceConfigResource {
    */
   private async listOverviewFromDiagnostics(): Promise<InterfaceOverview[]> {
     if (this.debugMode) {
-      console.log('[InterfaceConfig] Fetching interfaces via diagnostics endpoints');
+      logger.debug('[InterfaceConfig] Fetching interfaces via diagnostics endpoints');
     }
 
     // Get interface names
@@ -113,7 +114,7 @@ export class InterfaceConfigResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log('[InterfaceConfig] getInterfaceNames failed:', error);
+        logger.debug('[InterfaceConfig] getInterfaceNames failed:', error);
       }
     }
 
@@ -126,7 +127,7 @@ export class InterfaceConfigResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log('[InterfaceConfig] getInterfaceStatistics failed:', error);
+        logger.debug('[InterfaceConfig] getInterfaceStatistics failed:', error);
       }
     }
 
@@ -139,7 +140,7 @@ export class InterfaceConfigResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log('[InterfaceConfig] getInterfaceConfig failed:', error);
+        logger.debug('[InterfaceConfig] getInterfaceConfig failed:', error);
       }
     }
 
@@ -176,7 +177,7 @@ export class InterfaceConfigResource {
     }
 
     if (this.debugMode) {
-      console.log(`[InterfaceConfig] Diagnostics fallback found ${interfaces.length} interfaces`);
+      logger.debug(`[InterfaceConfig] Diagnostics fallback found ${interfaces.length} interfaces`);
     }
 
     return interfaces;
@@ -219,7 +220,7 @@ export class InterfaceConfigResource {
    */
   async getInterfaceConfig(interfaceName: string): Promise<InterfaceConfig | null> {
     if (this.debugMode) {
-      console.log(`[InterfaceConfig] Getting config for interface: ${interfaceName}`);
+      logger.debug(`[InterfaceConfig] Getting config for interface: ${interfaceName}`);
     }
 
     try {
@@ -235,7 +236,7 @@ export class InterfaceConfigResource {
           const response = await this.client.get(endpoint);
           
           if (this.debugMode) {
-            console.log(`[InterfaceConfig] ${endpoint} response:`, {
+            logger.debug(`[InterfaceConfig] ${endpoint} response:`, {
               hasInterface: !!response?.interface,
               hasSettings: !!response?.settings,
               keys: Object.keys(response || {})
@@ -250,12 +251,12 @@ export class InterfaceConfigResource {
           }
         } catch (error) {
           if (this.debugMode) {
-            console.log(`[InterfaceConfig] ${endpoint} failed:`, error);
+            logger.debug(`[InterfaceConfig] ${endpoint} failed:`, error);
           }
         }
       }
     } catch (error) {
-      console.error(`Error getting interface config for ${interfaceName}:`, error);
+      logger.error(`Error getting interface config for ${interfaceName}:`, error);
     }
 
     return null;
@@ -266,7 +267,7 @@ export class InterfaceConfigResource {
    */
   async updateInterfaceConfig(interfaceName: string, config: Partial<InterfaceConfig>): Promise<boolean> {
     if (this.debugMode) {
-      console.log(`[InterfaceConfig] Updating interface ${interfaceName}:`, config);
+      logger.debug(`[InterfaceConfig] Updating interface ${interfaceName}:`, config);
     }
 
     try {
@@ -283,7 +284,7 @@ export class InterfaceConfigResource {
           const response = await this.client.post(endpoint.path, payload);
           
           if (this.debugMode) {
-            console.log(`[InterfaceConfig] ${endpoint.path} response:`, response);
+            logger.debug(`[InterfaceConfig] ${endpoint.path} response:`, response);
           }
 
           if (response?.result === 'saved' || response?.status === 'ok') {
@@ -295,12 +296,12 @@ export class InterfaceConfigResource {
           }
         } catch (error) {
           if (this.debugMode) {
-            console.log(`[InterfaceConfig] ${endpoint.path} failed:`, error);
+            logger.debug(`[InterfaceConfig] ${endpoint.path} failed:`, error);
           }
         }
       }
     } catch (error) {
-      console.error(`Error updating interface ${interfaceName}:`, error);
+      logger.error(`Error updating interface ${interfaceName}:`, error);
     }
 
     return false;
@@ -311,19 +312,19 @@ export class InterfaceConfigResource {
    * This removes the "Block private networks" and "Block bogons" settings
    */
   async enableInterVLANRoutingOnInterface(interfaceName: string): Promise<boolean> {
-    console.log(`[InterfaceConfig] Enabling inter-VLAN routing on ${interfaceName}...`);
+    logger.debug(`[InterfaceConfig] Enabling inter-VLAN routing on ${interfaceName}...`);
 
     try {
       // Get current configuration
       const currentConfig = await this.getInterfaceConfig(interfaceName);
       
       if (!currentConfig) {
-        console.error(`Interface ${interfaceName} not found`);
+        logger.error(`Interface ${interfaceName} not found`);
         return false;
       }
 
       if (this.debugMode) {
-        console.log('[InterfaceConfig] Current interface config:', {
+        logger.debug('[InterfaceConfig] Current interface config:', {
           name: interfaceName,
           blockpriv: currentConfig.blockpriv,
           blockbogons: currentConfig.blockbogons
@@ -339,14 +340,14 @@ export class InterfaceConfigResource {
       const success = await this.updateInterfaceConfig(interfaceName, updatedConfig);
       
       if (success) {
-        console.log(`[InterfaceConfig] Inter-VLAN routing enabled on ${interfaceName}`);
+        logger.debug(`[InterfaceConfig] Inter-VLAN routing enabled on ${interfaceName}`);
       } else {
-        console.log(`[InterfaceConfig] Failed to enable inter-VLAN routing on ${interfaceName}`);
+        logger.debug(`[InterfaceConfig] Failed to enable inter-VLAN routing on ${interfaceName}`);
       }
 
       return success;
     } catch (error) {
-      console.error(`Error enabling inter-VLAN routing on ${interfaceName}:`, error);
+      logger.error(`Error enabling inter-VLAN routing on ${interfaceName}:`, error);
       return false;
     }
   }
@@ -355,7 +356,7 @@ export class InterfaceConfigResource {
    * Enable inter-VLAN routing on all interfaces
    */
   async enableInterVLANRoutingOnAllInterfaces(): Promise<{ success: boolean; details: any[] }> {
-    console.log('[InterfaceConfig] Enabling inter-VLAN routing on all interfaces...');
+    logger.debug('[InterfaceConfig] Enabling inter-VLAN routing on all interfaces...');
 
     const results: any[] = [];
     const interfaces = await this.listOverview();
@@ -407,7 +408,7 @@ export class InterfaceConfigResource {
    * Configure DMZ interface for inter-VLAN routing
    */
   async configureDMZInterface(dmzInterface: string = 'opt8'): Promise<boolean> {
-    console.log(`[InterfaceConfig] Configuring DMZ interface ${dmzInterface} for inter-VLAN routing...`);
+    logger.debug(`[InterfaceConfig] Configuring DMZ interface ${dmzInterface} for inter-VLAN routing...`);
 
     try {
       // Enable inter-VLAN routing on DMZ interface
@@ -427,7 +428,7 @@ export class InterfaceConfigResource {
 
       return success;
     } catch (error) {
-      console.error(`Error configuring DMZ interface ${dmzInterface}:`, error);
+      logger.error(`Error configuring DMZ interface ${dmzInterface}:`, error);
       return false;
     }
   }
@@ -437,7 +438,7 @@ export class InterfaceConfigResource {
    */
   async applyChanges(): Promise<void> {
     if (this.debugMode) {
-      console.log('[InterfaceConfig] Applying interface changes');
+      logger.debug('[InterfaceConfig] Applying interface changes');
     }
 
     const applyEndpoints = [
@@ -449,11 +450,11 @@ export class InterfaceConfigResource {
       try {
         await this.client.post(endpoint);
         if (this.debugMode) {
-          console.log(`[InterfaceConfig] Applied changes via ${endpoint}`);
+          logger.debug(`[InterfaceConfig] Applied changes via ${endpoint}`);
         }
       } catch (error) {
         if (this.debugMode) {
-          console.log(`[InterfaceConfig] ${endpoint} failed:`, error);
+          logger.debug(`[InterfaceConfig] ${endpoint} failed:`, error);
         }
       }
     }
@@ -466,7 +467,7 @@ export class InterfaceConfigResource {
    * Debug method to discover interface endpoints
    */
   async debugDiscoverEndpoints(): Promise<void> {
-    console.log('\n[InterfaceConfig] Discovering interface endpoints...');
+    logger.debug('[InterfaceConfig] Discovering interface endpoints...');
 
     const testEndpoints = [
       '/interfaces/overview/list',
@@ -483,8 +484,7 @@ export class InterfaceConfigResource {
     for (const endpoint of testEndpoints) {
       try {
         const response = await this.client.get(endpoint);
-        console.log(`\n${endpoint}:`);
-        console.log('  Success - Response structure:', {
+        logger.debug(`${endpoint}: Success - Response structure:`, {
           isArray: Array.isArray(response),
           keys: Object.keys(response || {}).slice(0, 10),
           hasRows: !!response?.rows,
@@ -493,13 +493,13 @@ export class InterfaceConfigResource {
 
         // Check for interface-specific settings
         if (response && typeof response === 'object') {
-          const interfaces = Array.isArray(response) ? response : 
-                            response.rows ? response.rows : 
+          const interfaces = Array.isArray(response) ? response :
+                            response.rows ? response.rows :
                             [response];
-          
+
           for (const iface of interfaces.slice(0, 2)) {
             if (iface.blockpriv !== undefined || iface.blockbogons !== undefined) {
-              console.log('  Found interface settings:', {
+              logger.debug('  Found interface settings:', {
                 name: iface.name || iface.descr,
                 blockpriv: iface.blockpriv,
                 blockbogons: iface.blockbogons
@@ -508,8 +508,7 @@ export class InterfaceConfigResource {
           }
         }
       } catch (error: any) {
-        console.log(`\n${endpoint}:`);
-        console.log('  Failed:', error?.message || error);
+        logger.debug(`${endpoint}: Failed:`, error?.message || error);
       }
     }
   }
@@ -526,7 +525,7 @@ export class InterfaceConfigResource {
       }
     } catch (error) {
       if (this.debugMode) {
-        console.log(`[InterfaceConfig] Legacy stats endpoint failed for ${interfaceName}, trying diagnostics`);
+        logger.debug(`[InterfaceConfig] Legacy stats endpoint failed for ${interfaceName}, trying diagnostics`);
       }
     }
 
@@ -537,7 +536,7 @@ export class InterfaceConfigResource {
         return response[interfaceName];
       }
     } catch (error) {
-      console.error(`Error getting statistics for ${interfaceName}:`, error);
+      logger.error(`Error getting statistics for ${interfaceName}:`, error);
     }
 
     return null;

--- a/src/resources/services/dhcp/leases.ts
+++ b/src/resources/services/dhcp/leases.ts
@@ -1,5 +1,6 @@
 // DHCP Lease Management Resource - FIXED VERSION
 import { OPNSenseAPIClient } from '../../../api/client.js';
+import { logger } from '../../../utils/logger.js';
 
 export interface DhcpLease {
   address: string;          // IP address
@@ -74,7 +75,7 @@ export class DhcpLeaseResource {
   async listLeases(): Promise<DhcpLease[]> {
     try {
       if (this.debugMode) {
-        console.log('[DHCP] Calling searchLease endpoint...');
+        logger.debug('[DHCP] Calling searchLease endpoint...');
       }
 
       const response = await this.client.post('/dhcpv4/leases/searchLease', {
@@ -85,7 +86,7 @@ export class DhcpLeaseResource {
       });
 
       if (this.debugMode) {
-        console.log('[DHCP] Raw response:', JSON.stringify(response, null, 2));
+        logger.debug('[DHCP] Raw response:', JSON.stringify(response, null, 2));
       }
 
       // Handle different response formats
@@ -102,9 +103,9 @@ export class DhcpLeaseResource {
       }
 
       if (this.debugMode) {
-        console.log(`[DHCP] Found ${leases.length} leases`);
+        logger.debug(`[DHCP] Found ${leases.length} leases`);
         if (leases.length > 0) {
-          console.log('[DHCP] First lease:', JSON.stringify(leases[0], null, 2));
+          logger.debug('[DHCP] First lease:', JSON.stringify(leases[0], null, 2));
         }
       }
 
@@ -112,13 +113,13 @@ export class DhcpLeaseResource {
       return leases.map(lease => this.normalizeLease(lease));
     } catch (error) {
       if (this.debugMode) {
-        console.error('[DHCP] Failed to list leases:', error);
+        logger.error('[DHCP] Failed to list leases:', error);
       }
       
       // Try alternative endpoint
       try {
         if (this.debugMode) {
-          console.log('[DHCP] Trying alternative endpoint...');
+          logger.debug('[DHCP] Trying alternative endpoint...');
         }
         
         const altResponse = await this.client.get('/dhcpv4/leases');
@@ -127,11 +128,11 @@ export class DhcpLeaseResource {
         }
       } catch (altError) {
         if (this.debugMode) {
-          console.error('[DHCP] Alternative endpoint also failed:', altError);
+          logger.error('[DHCP] Alternative endpoint also failed:', altError);
         }
       }
       
-      console.error('Failed to list DHCP leases:', error instanceof Error ? error.message : 'Unknown error');
+      logger.error('Failed to list DHCP leases:', error instanceof Error ? error.message : 'Unknown error');
       return [];
     }
   }
@@ -326,7 +327,7 @@ export class DhcpLeaseResource {
    * Debug method to test API endpoints
    */
   async debugApiEndpoints(): Promise<void> {
-    console.log('=== Debugging DHCP API Endpoints ===\n');
+    logger.debug('Debugging DHCP API Endpoints');
 
     // Test various endpoints
     const endpoints = [
@@ -337,17 +338,16 @@ export class DhcpLeaseResource {
     ];
 
     for (const endpoint of endpoints) {
-      console.log(`Testing ${endpoint.method} ${endpoint.path}...`);
+      logger.debug(`Testing ${endpoint.method} ${endpoint.path}...`);
       try {
-        const response = endpoint.method === 'POST' 
+        const response = endpoint.method === 'POST'
           ? await this.client.post(endpoint.path, endpoint.data || {})
           : await this.client.get(endpoint.path);
-        
-        console.log('Success! Response structure:', JSON.stringify(response, null, 2).substring(0, 500));
+
+        logger.debug('Success! Response structure:', JSON.stringify(response, null, 2).substring(0, 500));
       } catch (error: any) {
-        console.log('Failed:', error.message);
+        logger.debug('Failed:', error.message);
       }
-      console.log();
     }
   }
 }

--- a/src/resources/services/dns/blocklist.ts
+++ b/src/resources/services/dns/blocklist.ts
@@ -1,4 +1,5 @@
 import { OPNSenseAPIClient } from '../../../api/client.js';
+import { logger } from '../../../utils/logger.js';
 
 /**
  * OPNsense API response shapes for Unbound DNSBL / host override data.
@@ -180,7 +181,7 @@ export class DnsBlocklistResource {
 
       return { subscriptions, manualBlocks };
     } catch (error: any) {
-      console.error('Failed to list DNS blocklist:', error);
+      logger.error('Failed to list DNS blocklist:', error);
       throw new Error(`Failed to list DNS blocklist: ${error.message}`);
     }
   }
@@ -224,7 +225,7 @@ export class DnsBlocklistResource {
 
       throw new Error('Failed to add domain to blocklist');
     } catch (error: any) {
-      console.error('Failed to block domain:', error);
+      logger.error('Failed to block domain:', error);
       throw new Error(`Failed to block domain: ${error.message}`);
     }
   }
@@ -244,7 +245,7 @@ export class DnsBlocklistResource {
       await this.client.delUnboundHost(entry.uuid);
       await this.applyChanges();
     } catch (error: any) {
-      console.error('Failed to unblock domain:', error);
+      logger.error('Failed to unblock domain:', error);
       throw new Error(`Failed to unblock domain: ${error.message}`);
     }
   }
@@ -261,7 +262,7 @@ export class DnsBlocklistResource {
         await this.blockDomain(domain, description);
         blocked.push(domain);
       } catch (error) {
-        console.error(`Failed to block ${domain}:`, error);
+        logger.error(`Failed to block ${domain}:`, error);
         failed.push(domain);
       }
     }
@@ -275,7 +276,7 @@ export class DnsBlocklistResource {
    */
   async getInterfaceBlocklist(interfaceName: string): Promise<DnsBlocklistResult> {
     const allBlocked = await this.list();
-    console.warn(`Interface-specific filtering for ${interfaceName} requires ACL configuration`);
+    logger.warn(`Interface-specific filtering for ${interfaceName} requires ACL configuration`);
     return allBlocked;
   }
 
@@ -331,7 +332,7 @@ export class DnsBlocklistResource {
       await this.client.setUnboundHost(uuid, updated);
       await this.applyChanges();
     } catch (error: any) {
-      console.error('Failed to toggle blocklist entry:', error);
+      logger.error('Failed to toggle blocklist entry:', error);
       throw new Error(`Failed to toggle blocklist entry: ${error.message}`);
     }
   }
@@ -545,7 +546,7 @@ export class DnsBlocklistResource {
     try {
       await this.client.applyUnboundChanges();
     } catch (error: any) {
-      console.error('Failed to apply DNS changes:', error);
+      logger.error('Failed to apply DNS changes:', error);
       throw new Error(`Failed to apply DNS changes: ${error.message}`);
     }
   }

--- a/src/resources/system/settings.ts
+++ b/src/resources/system/settings.ts
@@ -1,6 +1,7 @@
 // System Settings Resource Implementation
 // Manages OPNsense system-level settings including inter-VLAN routing
 import { OPNSenseAPIClient } from '../../api/client.js';
+import { logger } from '../../utils/logger.js';
 
 export interface SystemSettings {
   firewall?: FirewallSettings;
@@ -65,7 +66,7 @@ export class SystemSettingsResource {
    */
   async getFirewallSettings(): Promise<FirewallSettings | null> {
     if (this.debugMode) {
-      console.log('[SystemSettings] Getting firewall settings');
+      logger.debug('[SystemSettings] Getting firewall settings');
     }
 
     try {
@@ -81,7 +82,7 @@ export class SystemSettingsResource {
           const response = await this.client.get(endpoint);
           
           if (this.debugMode) {
-            console.log(`[SystemSettings] ${endpoint} response:`, {
+            logger.debug(`[SystemSettings] ${endpoint} response:`, {
               hasSettings: !!response?.settings,
               hasFirewall: !!response?.firewall,
               keys: Object.keys(response || {})
@@ -95,12 +96,12 @@ export class SystemSettingsResource {
           }
         } catch (error) {
           if (this.debugMode) {
-            console.log(`[SystemSettings] ${endpoint} failed:`, error);
+            logger.debug(`[SystemSettings] ${endpoint} failed:`, error);
           }
         }
       }
     } catch (error) {
-      console.error('Error getting firewall settings:', error);
+      logger.error('Error getting firewall settings:', error);
     }
 
     return null;
@@ -111,7 +112,7 @@ export class SystemSettingsResource {
    */
   async updateFirewallSettings(settings: Partial<FirewallSettings>): Promise<boolean> {
     if (this.debugMode) {
-      console.log('[SystemSettings] Updating firewall settings:', settings);
+      logger.debug('[SystemSettings] Updating firewall settings:', settings);
     }
 
     try {
@@ -128,7 +129,7 @@ export class SystemSettingsResource {
           const response = await this.client.post(endpoint.path, payload);
           
           if (this.debugMode) {
-            console.log(`[SystemSettings] ${endpoint.path} response:`, response);
+            logger.debug(`[SystemSettings] ${endpoint.path} response:`, response);
           }
 
           if (response?.result === 'saved' || response?.status === 'ok') {
@@ -138,12 +139,12 @@ export class SystemSettingsResource {
           }
         } catch (error) {
           if (this.debugMode) {
-            console.log(`[SystemSettings] ${endpoint.path} failed:`, error);
+            logger.debug(`[SystemSettings] ${endpoint.path} failed:`, error);
           }
         }
       }
     } catch (error) {
-      console.error('Error updating firewall settings:', error);
+      logger.error('Error updating firewall settings:', error);
     }
 
     return false;
@@ -154,14 +155,14 @@ export class SystemSettingsResource {
    * This disables the blocking of private networks and enables routing between VLANs
    */
   async enableInterVLANRouting(): Promise<boolean> {
-    console.log('[SystemSettings] Enabling inter-VLAN routing...');
+    logger.debug('[SystemSettings] Enabling inter-VLAN routing...');
 
     try {
       // Get current settings
       const currentSettings = await this.getFirewallSettings();
       
       if (this.debugMode) {
-        console.log('[SystemSettings] Current settings:', currentSettings);
+        logger.debug('[SystemSettings] Current settings:', currentSettings);
       }
 
       // Update settings to enable inter-VLAN routing
@@ -176,14 +177,14 @@ export class SystemSettingsResource {
       const success = await this.updateFirewallSettings(updatedSettings);
       
       if (success) {
-        console.log('[SystemSettings] Inter-VLAN routing enabled successfully');
+        logger.debug('[SystemSettings] Inter-VLAN routing enabled successfully');
       } else {
-        console.log('[SystemSettings] Failed to enable inter-VLAN routing');
+        logger.debug('[SystemSettings] Failed to enable inter-VLAN routing');
       }
 
       return success;
     } catch (error) {
-      console.error('Error enabling inter-VLAN routing:', error);
+      logger.error('Error enabling inter-VLAN routing:', error);
       return false;
     }
   }
@@ -193,14 +194,14 @@ export class SystemSettingsResource {
    */
   async getRoutingSettings(): Promise<RoutingSettings | null> {
     if (this.debugMode) {
-      console.log('[SystemSettings] Getting routing settings');
+      logger.debug('[SystemSettings] Getting routing settings');
     }
 
     try {
       const response = await this.client.get('/routing/settings/get');
       return response?.settings || response || null;
     } catch (error) {
-      console.error('Error getting routing settings:', error);
+      logger.error('Error getting routing settings:', error);
       return null;
     }
   }
@@ -210,7 +211,7 @@ export class SystemSettingsResource {
    */
   async updateRoutingSettings(settings: Partial<RoutingSettings>): Promise<boolean> {
     if (this.debugMode) {
-      console.log('[SystemSettings] Updating routing settings:', settings);
+      logger.debug('[SystemSettings] Updating routing settings:', settings);
     }
 
     try {
@@ -221,7 +222,7 @@ export class SystemSettingsResource {
         return true;
       }
     } catch (error) {
-      console.error('Error updating routing settings:', error);
+      logger.error('Error updating routing settings:', error);
     }
 
     return false;
@@ -252,7 +253,7 @@ export class SystemSettingsResource {
       const response = await this.client.get('/system/settings/general/get');
       return response?.settings || response || null;
     } catch (error) {
-      console.error('Error getting general settings:', error);
+      logger.error('Error getting general settings:', error);
       return null;
     }
   }
@@ -262,7 +263,7 @@ export class SystemSettingsResource {
    */
   async applySettings(): Promise<void> {
     if (this.debugMode) {
-      console.log('[SystemSettings] Applying settings changes');
+      logger.debug('[SystemSettings] Applying settings changes');
     }
 
     const applyEndpoints = [
@@ -275,11 +276,11 @@ export class SystemSettingsResource {
       try {
         await this.client.post(endpoint);
         if (this.debugMode) {
-          console.log(`[SystemSettings] Applied changes via ${endpoint}`);
+          logger.debug(`[SystemSettings] Applied changes via ${endpoint}`);
         }
       } catch (error) {
         if (this.debugMode) {
-          console.log(`[SystemSettings] ${endpoint} failed:`, error);
+          logger.debug(`[SystemSettings] ${endpoint} failed:`, error);
         }
       }
     }
@@ -292,7 +293,7 @@ export class SystemSettingsResource {
    * Debug method to discover available settings endpoints
    */
   async debugDiscoverEndpoints(): Promise<void> {
-    console.log('\n[SystemSettings] Discovering settings endpoints...');
+    logger.debug('[SystemSettings] Discovering settings endpoints...');
 
     const testEndpoints = [
       '/firewall/settings/get',
@@ -308,30 +309,28 @@ export class SystemSettingsResource {
     for (const endpoint of testEndpoints) {
       try {
         const response = await this.client.get(endpoint);
-        console.log(`\n${endpoint}:`);
-        console.log('  Success - Response structure:', {
+        logger.debug(`${endpoint}: Success - Response structure:`, {
           keys: Object.keys(response || {}),
           hasSettings: !!response?.settings,
           hasFirewall: !!response?.firewall,
           hasAdvanced: !!response?.advanced
         });
-        
+
         // Log specific settings if found
         if (response?.settings || response?.firewall || response?.advanced) {
           const settings = response.settings || response.firewall || response.advanced;
-          const relevantKeys = Object.keys(settings).filter(key => 
-            key.includes('block') || 
-            key.includes('route') || 
+          const relevantKeys = Object.keys(settings).filter(key =>
+            key.includes('block') ||
+            key.includes('route') ||
             key.includes('vlan') ||
             key.includes('inter')
           );
           if (relevantKeys.length > 0) {
-            console.log('  Relevant settings found:', relevantKeys);
+            logger.debug('  Relevant settings found:', relevantKeys);
           }
         }
       } catch (error: any) {
-        console.log(`\n${endpoint}:`);
-        console.log('  Failed:', error?.message || error);
+        logger.debug(`${endpoint}: Failed:`, error?.message || error);
       }
     }
   }

--- a/src/server-v2.ts
+++ b/src/server-v2.ts
@@ -12,7 +12,7 @@ import { OPNSenseAPIClient } from './api/client.js';
 import { SSHExecutor } from './resources/ssh/executor.js';
 import { MCPCacheManager } from './cache/manager.js';
 import { ResourceStateStore } from './state/store.js';
-import { Logger, LogLevel } from './utils/logger.js';
+import { Logger, LogLevel, logger } from './utils/logger.js';
 import type { PluginContext } from './core/types/plugin.js';
 
 /**
@@ -354,18 +354,18 @@ if (require.main === module) {
 
       // Graceful shutdown
       process.on('SIGINT', async () => {
-        console.log('\nReceived SIGINT, shutting down gracefully...');
+        logger.info('Received SIGINT, shutting down gracefully...');
         await server.stop();
         process.exit(0);
       });
 
       process.on('SIGTERM', async () => {
-        console.log('\nReceived SIGTERM, shutting down gracefully...');
+        logger.info('Received SIGTERM, shutting down gracefully...');
         await server.stop();
         process.exit(0);
       });
     } catch (error) {
-      console.error('Failed to start server:', error);
+      logger.error('Failed to start server:', error);
       process.exit(1);
     }
   })();

--- a/src/transports/SSETransportServer.ts
+++ b/src/transports/SSETransportServer.ts
@@ -3,6 +3,7 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { TransportOptions } from "./types.js";
+import { logger } from "../utils/logger.js";
 
 interface SSEConnection {
   transport: SSEServerTransport;
@@ -83,17 +84,17 @@ export class SSETransportServer {
 
       this.server.on("error", reject);
       this.server.listen(this.port, this.host, () => {
-        console.log(
+        logger.info(
           `MCP Server listening on http://${this.host}:${this.port}`,
         );
-        console.log(
+        logger.info(
           `- Streamable HTTP endpoint: http://${this.host}:${this.port}/mcp`,
         );
-        console.log(`- SSE endpoint: http://${this.host}:${this.port}/sse`);
-        console.log(
+        logger.info(`- SSE endpoint: http://${this.host}:${this.port}/sse`);
+        logger.info(
           `- Messages endpoint: http://${this.host}:${this.port}/messages`,
         );
-        console.log(`- Health check: http://${this.host}:${this.port}/health`);
+        logger.info(`- Health check: http://${this.host}:${this.port}/health`);
         resolve();
       });
     });
@@ -140,13 +141,13 @@ export class SSETransportServer {
             transport.onclose = () => {
               if (newSessionId) {
                 this.streamableTransports.delete(newSessionId);
-                console.log(
+                logger.info(
                   `Streamable HTTP session closed: ${newSessionId}`,
                 );
               }
             };
 
-            console.log(
+            logger.info(
               `New Streamable HTTP session established: ${newSessionId}`,
             );
           }
@@ -172,7 +173,7 @@ export class SSETransportServer {
           const transport = this.streamableTransports.get(sessionId)!;
           await transport.handleRequest(req, res);
           this.streamableTransports.delete(sessionId);
-          console.log(`Streamable HTTP session terminated: ${sessionId}`);
+          logger.info(`Streamable HTTP session terminated: ${sessionId}`);
         } else {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(
@@ -186,7 +187,7 @@ export class SSETransportServer {
         res.end(JSON.stringify({ error: "Method not allowed" }));
       }
     } catch (error) {
-      console.error("Error handling Streamable HTTP request:", error);
+      logger.error("Error handling Streamable HTTP request:", error);
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Internal server error" }));
@@ -224,7 +225,7 @@ export class SSETransportServer {
 
       if (sessionId) {
         this.connections.set(sessionId, { transport, sessionId });
-        console.log(`New SSE connection established: ${sessionId}`);
+        logger.info(`New SSE connection established: ${sessionId}`);
       }
 
       // Notify that a new connection is ready
@@ -237,11 +238,11 @@ export class SSETransportServer {
       req.on("close", () => {
         if (sessionId) {
           this.connections.delete(sessionId);
-          console.log(`SSE connection closed: ${sessionId}`);
+          logger.info(`SSE connection closed: ${sessionId}`);
         }
       });
     } catch (error) {
-      console.error("Error handling SSE connection:", error);
+      logger.error("Error handling SSE connection:", error);
       // Don't write headers if SSE has already started
       if (!res.headersSent) {
         res.writeHead(500);
@@ -274,7 +275,7 @@ export class SSETransportServer {
       // Let the transport handle the message
       await connection.transport.handlePostMessage(req, res);
     } catch (error) {
-      console.error("Error handling POST message:", error);
+      logger.error("Error handling POST message:", error);
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Internal server error" }));
     }
@@ -316,7 +317,7 @@ export class SSETransportServer {
         try {
           (connection.transport as any).close();
         } catch (error) {
-          console.error("Error closing SSE connection:", error);
+          logger.error("Error closing SSE connection:", error);
         }
       }
       this.connections.clear();
@@ -326,7 +327,7 @@ export class SSETransportServer {
         try {
           transport.close();
         } catch (error) {
-          console.error(
+          logger.error(
             `Error closing Streamable HTTP session ${sessionId}:`,
             error,
           );
@@ -336,7 +337,7 @@ export class SSETransportServer {
 
       if (this.server) {
         this.server.close(() => {
-          console.log("MCP Server stopped");
+          logger.info("MCP Server stopped");
           resolve();
         });
       } else {

--- a/src/utils/interface-mapper.ts
+++ b/src/utils/interface-mapper.ts
@@ -1,6 +1,8 @@
 // Interface mapping utility for OPNsense API
 // Maps user-friendly interface names to OPNsense internal keys
 
+import { logger } from './logger.js';
+
 export interface InterfaceMapping {
   [key: string]: string;
 }
@@ -44,7 +46,7 @@ export class InterfaceMapper {
         const customMappings = JSON.parse(process.env.OPNSENSE_INTERFACE_MAPPINGS);
         Object.assign(this.interfaceMap, customMappings);
       } catch (e) {
-        console.warn('Failed to parse OPNSENSE_INTERFACE_MAPPINGS:', e);
+        logger.warn('Failed to parse OPNSENSE_INTERFACE_MAPPINGS:', e);
       }
     }
     
@@ -123,7 +125,7 @@ export class InterfaceMapper {
     }
     
     // Return as-is if no mapping found
-    console.warn(`No mapping found for interface: ${userInterface}`);
+    logger.warn(`No mapping found for interface: ${userInterface}`);
     return userInterface;
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,19 @@
 /**
- * Simple logger utility for OPNSense MCP Server
+ * Logger utility for OPNSense MCP Server
+ *
+ * Supports file logging via LOG_FILE environment variable.
+ * When running with stdio transport, file logging is critical since
+ * stdout is reserved for JSON-RPC and stderr may not be captured.
+ *
+ * Environment variables:
+ *   LOG_LEVEL   - ERROR, WARN, INFO, DEBUG (default: INFO)
+ *   LOG_FILE    - Path to log file (default: none, stderr only)
+ *   LOG_MAX_SIZE - Max log file size in bytes before rotation (default: 10MB)
+ *   LOG_MAX_FILES - Number of rotated log files to keep (default: 5)
  */
+
+import { createWriteStream, statSync, renameSync, unlinkSync, existsSync, mkdirSync, type WriteStream } from 'node:fs';
+import { dirname } from 'node:path';
 
 export enum LogLevel {
   ERROR = 0,
@@ -14,10 +27,18 @@ export interface LoggerConfig {
   prefix?: string;
   timestamp?: boolean;
   output?: 'stdout' | 'stderr';
+  logFile?: string;
+  maxFileSize?: number;
+  maxFiles?: number;
 }
+
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const DEFAULT_MAX_FILES = 5;
 
 export class Logger {
   private config: LoggerConfig;
+  private fileStream: WriteStream | null = null;
+  private currentFileSize = 0;
 
   constructor(config?: Partial<LoggerConfig>) {
     this.config = {
@@ -32,6 +53,109 @@ export class Logger {
     const envLevel = process.env.LOG_LEVEL?.toUpperCase();
     if (envLevel && LogLevel[envLevel as keyof typeof LogLevel] !== undefined) {
       this.config.level = LogLevel[envLevel as keyof typeof LogLevel];
+    }
+
+    // Set log file from environment (constructor config takes precedence)
+    if (!this.config.logFile && process.env.LOG_FILE) {
+      this.config.logFile = process.env.LOG_FILE;
+    }
+
+    if (!this.config.maxFileSize && process.env.LOG_MAX_SIZE) {
+      this.config.maxFileSize = parseInt(process.env.LOG_MAX_SIZE, 10);
+    }
+
+    if (!this.config.maxFiles && process.env.LOG_MAX_FILES) {
+      this.config.maxFiles = parseInt(process.env.LOG_MAX_FILES, 10);
+    }
+
+    if (this.config.logFile) {
+      this.initFileLogging(this.config.logFile);
+    }
+  }
+
+  private initFileLogging(filePath: string): void {
+    try {
+      // Ensure the directory exists
+      const dir = dirname(filePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      // Get current file size if file exists
+      if (existsSync(filePath)) {
+        try {
+          this.currentFileSize = statSync(filePath).size;
+        } catch {
+          this.currentFileSize = 0;
+        }
+      }
+
+      this.fileStream = createWriteStream(filePath, { flags: 'a' });
+
+      this.fileStream.on('error', (err) => {
+        // Fall back to stderr if file logging fails
+        process.stderr.write(`[Logger] File logging error: ${err.message}\n`);
+        this.fileStream = null;
+      });
+    } catch (err: any) {
+      process.stderr.write(`[Logger] Failed to initialize file logging: ${err.message}\n`);
+    }
+  }
+
+  private rotateLogFile(): void {
+    const filePath = this.config.logFile;
+    if (!filePath) return;
+
+    const maxFiles = this.config.maxFiles ?? DEFAULT_MAX_FILES;
+
+    // Close current stream
+    if (this.fileStream) {
+      this.fileStream.end();
+      this.fileStream = null;
+    }
+
+    try {
+      // Remove oldest file
+      const oldest = `${filePath}.${maxFiles}`;
+      if (existsSync(oldest)) {
+        unlinkSync(oldest);
+      }
+
+      // Shift existing rotated files
+      for (let i = maxFiles - 1; i >= 1; i--) {
+        const from = `${filePath}.${i}`;
+        const to = `${filePath}.${i + 1}`;
+        if (existsSync(from)) {
+          renameSync(from, to);
+        }
+      }
+
+      // Rotate current file
+      if (existsSync(filePath)) {
+        renameSync(filePath, `${filePath}.1`);
+      }
+    } catch (err: any) {
+      process.stderr.write(`[Logger] Log rotation error: ${err.message}\n`);
+    }
+
+    // Reopen file
+    this.currentFileSize = 0;
+    this.initFileLogging(filePath);
+  }
+
+  private writeToFile(line: string): void {
+    if (!this.fileStream) return;
+
+    const maxSize = this.config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
+    const bytes = Buffer.byteLength(line, 'utf8');
+
+    if (this.currentFileSize + bytes > maxSize) {
+      this.rotateLogFile();
+    }
+
+    if (this.fileStream) {
+      this.fileStream.write(line);
+      this.currentFileSize += bytes;
     }
   }
 
@@ -50,7 +174,7 @@ export class Logger {
     parts.push(message);
 
     // Format additional arguments
-    const formattedArgs = args.map(arg => 
+    const formattedArgs = args.map(arg =>
       typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
     );
 
@@ -61,6 +185,11 @@ export class Logger {
     if (level > this.config.level) return;
 
     const formatted = this.format(levelName, message, ...args);
+
+    // Always write to file if configured
+    this.writeToFile(formatted + '\n');
+
+    // Write to console output (stderr by default to avoid polluting stdio transport)
     const output = this.config.output === 'stdout' ? console.log : console.error;
     output(formatted);
   }
@@ -81,11 +210,27 @@ export class Logger {
     this.log(LogLevel.DEBUG, 'DEBUG', message, ...args);
   }
 
-  // Create a child logger with additional context
+  // Create a child logger with additional context (shares file stream)
   child(context: string): Logger {
-    return new Logger({
+    const child = new Logger({
       ...this.config,
-      prefix: `${this.config.prefix} [${context}]`
+      prefix: `${this.config.prefix} [${context}]`,
+      logFile: undefined // Don't re-init file stream
+    });
+    // Share the parent's file stream
+    child.fileStream = this.fileStream;
+    child.currentFileSize = this.currentFileSize;
+    return child;
+  }
+
+  // Flush and close the file stream
+  close(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.fileStream) {
+        this.fileStream.end(() => resolve());
+      } else {
+        resolve();
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- **Adds file-based logging** via `LOG_FILE` environment variable with automatic log rotation (`LOG_MAX_SIZE`, `LOG_MAX_FILES`)
- **Migrates all 20 source files** from raw `console.log/error/warn` calls to the structured `logger` utility
- **Zero raw console calls remain** in the `src/` directory — all output goes through the centralized logger

## Motivation
Closes #48 — users running OPNSenseMCP with stdio transport (e.g., Codex, Claude Desktop) had no way to diagnose transport crashes or silent failures since stdout is reserved for JSON-RPC and stderr may not be captured by the MCP client.

## Usage
```toml
[mcp_servers.opnsense.env]
LOG_FILE = "/tmp/opnsense-mcp.log"
LOG_LEVEL = "DEBUG"
# LOG_MAX_SIZE = "10485760"   # 10MB default
# LOG_MAX_FILES = "5"         # 5 rotated files default
```

## Changes
| Area | Files | What changed |
|------|-------|-------------|
| Logger utility | `src/utils/logger.ts` | Added file write stream, rotation, `LOG_FILE`/`LOG_MAX_SIZE`/`LOG_MAX_FILES` env vars, `close()` method |
| API client | `src/api/client.ts` | `console.log` → `logger.debug` for request/response logging |
| Resources (8 files) | `src/resources/**` | All console calls → logger with appropriate levels |
| Database (3 files) | `src/db/**` | Migration/query logging → logger |
| Cache (2 files) | `src/cache/**` | Cache manager logging → logger |
| Transports | `src/transports/SSETransportServer.ts` | SSE lifecycle logging → logger |
| Other (4 files) | server-v2, event-bus, macro, interface-mapper | Remaining console calls → logger |
| Config | `.env.example` | Documented new logging env vars |

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Full build passes (`npm run build`)
- [x] Zero `console.log/error/warn` calls remain in `src/`
- [ ] Manual: start with `LOG_FILE=/tmp/test.log LOG_LEVEL=DEBUG` and verify file output
- [ ] Manual: verify log rotation triggers at configured size

🤖 Generated with [Claude Code](https://claude.com/claude-code)