### PR TITLE
fix: expose IPv6 addresses in interface_list_overview

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4311,9 +4311,12 @@ class OPNSenseMCPServer {
           try {
             const interfaces = await this.interfaceConfigResource!.listOverview();
             
-            const formatted = interfaces.map(iface => 
-              `${iface.name}: ${iface.device} - ${iface.status} (${iface.ipaddr || 'no IP'}/${iface.subnet || ''})`
-            );
+            const formatted = interfaces.map(iface => {
+              const ipv4 = iface.ipaddr ? `${iface.ipaddr}/${iface.subnet || ''}` : null;
+              const ipv6 = iface.ipaddr6 ? `${iface.ipaddr6}/${iface.subnet6 || ''}` : null;
+              const addrs = [ipv4, ipv6].filter(Boolean).join(', ') || 'no IP';
+              return `${iface.name}: ${iface.device} - ${iface.status} (${addrs})`;
+            });
             
             return {
               content: [{

--- a/src/resources/network/interfaces.ts
+++ b/src/resources/network/interfaces.ts
@@ -33,6 +33,9 @@ export interface InterfaceOverview {
   ipaddr?: string;
   subnet?: string;
   gateway?: string;
+  ipaddr6?: string;
+  subnet6?: string;
+  gateway6?: string;
   media?: string;
   statistics?: {
     packets_in: number;
@@ -164,6 +167,9 @@ export class InterfaceConfigResource {
         ipaddr: config.ipaddr || config.addr || config.ipv4?.[0]?.ipaddr,
         subnet: config.subnet || config.subnetbits || config.ipv4?.[0]?.subnetbits,
         gateway: config.gateway,
+        ipaddr6: config.ipaddrv6 || config.addr6 || config.ipv6?.[0]?.ipaddr,
+        subnet6: config.subnetv6 || config.prefixv6 || config.ipv6?.[0]?.subnetbits || config.ipv6?.[0]?.prefix,
+        gateway6: config.gatewayv6,
         media: config.media || stats.media,
         statistics: stats ? {
           packets_in: parseInt(stats['packets received'] || stats.inpkts || '0', 10),


### PR DESCRIPTION
## Summary
- Adds `ipaddr6`, `subnet6`, `gateway6` fields to `InterfaceOverview` type
- Extracts IPv6 data from OPNsense diagnostic API responses (`ipaddrv6`, `addr6`, `ipv6[]`)
- Updates formatted output to display both IPv4 and IPv6 addresses

Closes #67

## Test plan
- [ ] Call `interface_list_overview` on a firewall with IPv6 configured
- [ ] Verify IPv6 addresses appear alongside IPv4
- [ ] Verify interfaces with only IPv4 still display correctly
- [ ] Verify interfaces with only IPv6 display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)